### PR TITLE
Zero-propagation for concatenation

### DIFF
--- a/src/linops/indexing.jl
+++ b/src/linops/indexing.jl
@@ -17,7 +17,7 @@ Index each `c`th component `AbstractGP` of `f_q` at `X`.
 (f_q::BlockGP)(X::BlockData) = BlockGP(map((f, x)->f(x), f_q.fs, blocks(X)))
 (f_q::BlockGP)(X::AbstractVector) = BlockGP([f(X) for f in f_q.fs])
 
-μ_p′(f_q::GP, X::AVM) = FiniteMean(mean(f_q), X)
-k_p′(f_q::GP, X::AVM) = FiniteKernel(kernel(f_q), X)
+μ_p′(f_q::GP, X::AVM) = finite(mean(f_q), X)
+k_p′(f_q::GP, X::AVM) = finite(kernel(f_q), X)
 k_p′p(f_q::GP, X::AVM, f_p::GP) = lhsfinite(kernel(f_q, f_p), X)
 k_pp′(f_p::GP, f_q::GP, X′::AVM) = rhsfinite(kernel(f_p, f_q), X′)


### PR DESCRIPTION
As it turns out, good zero-propagation is crucial for achieving good performance when composing a GP with a (known, deterministic) function. This is unsurprising. This PR significantly improves zero-propagation in this context. As before, no testing because first year report.