### PR TITLE
Adds Toeplitz matrices

### DIFF
--- a/examples/toeplitz.jl
+++ b/examples/toeplitz.jl
@@ -1,0 +1,102 @@
+using Stheno, Random
+using Stheno: @model
+
+
+
+######################## Example 1: Vanilla Toeplitz ########################
+
+@model function vanilla()
+    f = GP(EQ())
+    y = f + GP(Noise(0.1))
+    return f, y
+end
+f, y = vanilla();
+
+# Create regularly spaced data. Dispatch handles literally everything else.
+x = range(-5.0, stop=5.0, length=10000);
+
+# Notice that we don't struggle to construct large covariances. All of these matrices
+# are either Toeplitz or SymmetricToeplitz. This structure is exploited to accelerate
+# all computations. These covariance matrices are constucted in O(N)-time.
+Σff = cov(f(x));
+Σfy = xcov(f(x), y(x));
+Σyy = cov(y(x));
+
+# These operations are also quite a lot faster. They occur in O(N^2)-time.
+rng = MersenneTwister(123456);
+ŷ = rand(rng, y(x));
+@show logpdf(y(x), ŷ);
+
+
+
+######################## Example 2: Block Vanilla Toeplitz ########################
+
+# Suppose that we have two separate blocks of regularly spaced data eg. missing data.
+xl, xr = linspace(-5.0, 0.0, 5000), linspace(0.0, 5.0, 5000);
+
+# If we inspect the underlying blocks of the covariance, we see they are all still Toeplitz.
+using Stheno: unbox
+f_xl_xr = BlockGP([f(xl), f(xr)]);
+y_xl_xr = BlockGP([y(xl), y(xr)]);
+Σff = cov(f_xl_xr);
+display(typeof.(unbox(unbox(Σff)).blocks));
+
+# DOESN'T APPEAR TO WORK WITH f(BlockData([xl, xr]))!!!!!!!!!!!!!!!!!!!!!!!!!
+
+# THIS CURRENTLY SEEMS A BIT SLOW! COMPARE TO DENSE PROPERLY!
+rng = MersenneTwister(123456);
+ŷ = rand(rng, y_xl_xr);
+@show logpdf(y_xl_xr, ŷ);
+
+
+
+######################### Example 3: Multi-Output Toeplitz ##########################
+
+# Suppose now that we modify our model slightly. We construct a two-output process from
+# three latent processes.
+@model function simple_multi_output()
+    f₁, f₂, f₃ = GP(EQ()), GP(EQ()), GP(EQ())
+    y₁, y₂ = f₁ + f₂, f₂ + f₃
+    return y₁, y₂
+end
+y₁, y₂ = simple_multi_output();
+
+# Observe both at x. The joint covariance matrix is still Toeplitz!
+y_1x_2x = BlockGP([y₁(x), y₂(x)]);
+Σ12 = cov(y_1x_2x);
+display(typeof.(unbox(unbox(Σ12)).blocks));
+
+# Same again for the missing data.
+y_1xl_2xr = BlockGP([y₁(xl), y₂(xr)]);
+Σ12 = cov(y_1xl_2xr);
+display(typeof.(unbox(unbox(Σ12)).blocks));
+
+
+
+######################### Example 4: Temporally mis-aligned data ##########################
+
+# What if each output has the same sampling rate, but the data are misaligned?
+x₁ = linspace(-5.0, 5.0, 5000);
+x₂ = x₁ + 0.3;
+
+# The joint covariance still comprises Toeplitz matrices.
+y_x1_x2 = BlockGP([y₁(x₁), y₂(x₂)]);
+Σ12 = cov(y_x1_x2);
+display(typeof.(unbox(unbox(Σ12)).blocks));
+
+
+
+######################### Example 5: Partial structure ###########################
+
+# Suppose that we have some regularly sampled data, and some structure-less data.
+x′ = randn(rng, 100);
+
+# Notice that Σ_x_x′ comprised three dense blocks, and one Toeplitz. This is because
+# cov(f(x′)) is dense, xcov(f(x), f(x′)) / xcov(f(x′), f(x)) is dense, whilst cov(f(x))
+# is Toeplitz.
+f_x_x′ = BlockGP([f(x), f(x′)]);
+Σ_x_x′ = cov(f_x_x′);
+display(typeof.(unbox(unbox(Σ_x_x′)).blocks)) 
+
+# Note that any combination of these things will (should) also yield some combination of
+# dense and Toeplitz matrices.

--- a/examples/toeplitz.jl
+++ b/examples/toeplitz.jl
@@ -32,7 +32,7 @@ ŷ = rand(rng, y(x));
 ######################## Example 2: Block Vanilla Toeplitz ########################
 
 # Suppose that we have two separate blocks of regularly spaced data eg. missing data.
-xl, xr = linspace(-5.0, 0.0, 5000), linspace(0.0, 5.0, 5000);
+xl, xr = range(-5.0, stop=0.0, length=5000), range(0.0, stop=5.0, length=5000);
 
 # If we inspect the underlying blocks of the covariance, we see they are all still Toeplitz.
 using Stheno: unbox
@@ -40,8 +40,6 @@ f_xl_xr = BlockGP([f(xl), f(xr)]);
 y_xl_xr = BlockGP([y(xl), y(xr)]);
 Σff = cov(f_xl_xr);
 display(typeof.(unbox(unbox(Σff)).blocks));
-
-# DOESN'T APPEAR TO WORK WITH f(BlockData([xl, xr]))!!!!!!!!!!!!!!!!!!!!!!!!!
 
 # THIS CURRENTLY SEEMS A BIT SLOW! COMPARE TO DENSE PROPERLY!
 rng = MersenneTwister(123456);
@@ -76,8 +74,8 @@ display(typeof.(unbox(unbox(Σ12)).blocks));
 ######################### Example 4: Temporally mis-aligned data ##########################
 
 # What if each output has the same sampling rate, but the data are misaligned?
-x₁ = linspace(-5.0, 5.0, 5000);
-x₂ = x₁ + 0.3;
+x₁ = range(-5.0, stop=5.0, length=5000);
+x₂ = x₁ .+ 0.3;
 
 # The joint covariance still comprises Toeplitz matrices.
 y_x1_x2 = BlockGP([y₁(x₁), y₂(x₂)]);

--- a/src/mean_and_kernel/kernel.jl
+++ b/src/mean_and_kernel/kernel.jl
@@ -105,23 +105,21 @@ end
 
 # Optimisation for Toeplitz covariance matrices.
 function pairwise(k::Kernel, x::StepRangeLen{<:Real})
-    return LazyPDMat(_pairwise(k, x))
-    # if isstationary(k)
-    #     return LazyPDMat(SymmetricToeplitz(map(k, x, Fill(x[1], length(x)))))
-    # else
-    #     return LazyPDMat(_pairwise(k, x))
-    # end
+    if isstationary(k)
+        return LazyPDMat(SymmetricToeplitz(map(k, x, Fill(x[1], length(x)))))
+    else
+        return LazyPDMat(_pairwise(k, x))
+    end
 end
 function pairwise(k::CrossKernel, x::StepRangeLen{<:Real}, x′::StepRangeLen{<:Real})
-    return _pairwise(k, x, x′)
-    # if isstationary(k) && x.ref == x′.ref
-    #     return Toeplitz(
-    #         map(k, x, Fill(x′[1], length(x))),
-    #         map(k, Fill(x[1], length(x′)), x′),
-    #     )
-    # else
-    #     return _pairwise(k, x, x′)
-    # end
+    if isstationary(k) && x.ref == x′.ref
+        return Toeplitz(
+            map(k, x, Fill(x′[1], length(x))),
+            map(k, Fill(x[1], length(x′)), x′),
+        )
+    else
+        return _pairwise(k, x, x′)
+    end
 end
 
 

--- a/src/mean_and_kernel/kernel.jl
+++ b/src/mean_and_kernel/kernel.jl
@@ -198,6 +198,16 @@ isstationary(::Type{<:PerEQ}) = true
 (k::PerEQ)(x::Real) = one(typeof(x))
 @inline eachindex(k::PerEQ) = eachindex_err(k)
 
+"""
+    Exponential <: Kernel
+
+The standardised Exponential kernel.
+"""
+struct Exponential <: Kernel end
+isstationary(::Type{<:Exponential}) = true
+(::Exponential)(x::Real, x′::Real) = exp(-abs(x - x′))
+(::Exponential)(x) = one(Float64)
+@inline eachindex(k::Exponential) = eachindex_err(k)
 
 # """
 #     RQ{T<:Real} <: Kernel
@@ -293,15 +303,7 @@ end
 #     min(x, x′)^3 / 3 + abs(x - x′) * min(x, x′)^2 / 2
 # show(io::IO, ::WienerVelocity) = show(io, "WienerVelocity")
 
-# """
-#     Exponential <: Kernel
 
-# The standardised Exponential kernel.
-# """
-# struct Exponential <: Kernel end
-# @inline (::Exponential)(x::Real, x′::Real) = exp(-abs(x - x′))
-# isstationary(::Type{<:Exponential}) = true
-# show(io::IO, ::Exponential) = show(io, "Exp")
 
 """
     EmpiricalKernel <: Kernel

--- a/src/mean_and_kernel/kernel.jl
+++ b/src/mean_and_kernel/kernel.jl
@@ -112,7 +112,7 @@ function pairwise(k::Kernel, x::StepRangeLen{<:Real})
     end
 end
 function pairwise(k::CrossKernel, x::StepRangeLen{<:Real}, x′::StepRangeLen{<:Real})
-    if isstationary(k) && x.ref == x′.ref
+    if isstationary(k) && x.step == x′.step
         return Toeplitz(
             map(k, x, Fill(x′[1], length(x))),
             map(k, Fill(x[1], length(x′)), x′),

--- a/src/util/block_arrays.jl
+++ b/src/util/block_arrays.jl
@@ -293,24 +293,24 @@ function *(A::LazyPDMat{T, <:Symmetric{T, <:ABM{T}}}, B::AdjTransTriABM{T}) wher
     return unbox(unbox(A)) * B
 end
 
-# THIS CODE SHOULD BE REMOVED ONCE A NEW VERSION OF FILLARRAYS HAS BEEN TAGGED!
-function *(a::Adjoint{T, <:AbstractVector{T}}, b::Zeros{S, 1}) where {T, S}
-    la, lb = length(a), length(b)
-    if la ≠ lb
-        throw(DimensionMismatch("dot product arguments have lengths $la and $lb"))
-    end
-    return zero(promote_type(T, S))
-end
-*(a::Adjoint{T, <:AbstractMatrix{T}} where T, b::Zeros{<:Any, 1}) = FillArrays.mult_zeros(a, b)
+# # THIS CODE SHOULD BE REMOVED ONCE A NEW VERSION OF FILLARRAYS HAS BEEN TAGGED!
+# function *(a::Adjoint{T, <:AbstractVector{T}}, b::Zeros{S, 1}) where {T, S}
+#     la, lb = length(a), length(b)
+#     if la ≠ lb
+#         throw(DimensionMismatch("dot product arguments have lengths $la and $lb"))
+#     end
+#     return zero(promote_type(T, S))
+# end
+# *(a::Adjoint{T, <:AbstractMatrix{T}} where T, b::Zeros{<:Any, 1}) = FillArrays.mult_zeros(a, b)
 
-function *(a::Transpose{T, <:AbstractVector{T}}, b::Zeros{T, 1}) where T<:Real
-    la, lb = length(a), length(b)
-    if la ≠ lb
-        throw(DimensionMismatch("dot product arguments have lengths $la and $lb"))
-    end
-    return zero(T)
-end
-*(a::Transpose{T, <:AbstractMatrix{T}}, b::Zeros{T, 1}) where T<:Real = FillArrays.mult_zeros(a, b)
+# function *(a::Transpose{T, <:AbstractVector{T}}, b::Zeros{T, 1}) where T<:Real
+#     la, lb = length(a), length(b)
+#     if la ≠ lb
+#         throw(DimensionMismatch("dot product arguments have lengths $la and $lb"))
+#     end
+#     return zero(T)
+# end
+# *(a::Transpose{T, <:AbstractMatrix{T}}, b::Zeros{T, 1}) where T<:Real = FillArrays.mult_zeros(a, b)
 
 const UpperOrAdjLower{T} = Union{
     UpperTriangular{T, <:ABM{T}},

--- a/src/util/block_arrays.jl
+++ b/src/util/block_arrays.jl
@@ -293,25 +293,6 @@ function *(A::LazyPDMat{T, <:Symmetric{T, <:ABM{T}}}, B::AdjTransTriABM{T}) wher
     return unbox(unbox(A)) * B
 end
 
-# # THIS CODE SHOULD BE REMOVED ONCE A NEW VERSION OF FILLARRAYS HAS BEEN TAGGED!
-# function *(a::Adjoint{T, <:AbstractVector{T}}, b::Zeros{S, 1}) where {T, S}
-#     la, lb = length(a), length(b)
-#     if la ≠ lb
-#         throw(DimensionMismatch("dot product arguments have lengths $la and $lb"))
-#     end
-#     return zero(promote_type(T, S))
-# end
-# *(a::Adjoint{T, <:AbstractMatrix{T}} where T, b::Zeros{<:Any, 1}) = FillArrays.mult_zeros(a, b)
-
-# function *(a::Transpose{T, <:AbstractVector{T}}, b::Zeros{T, 1}) where T<:Real
-#     la, lb = length(a), length(b)
-#     if la ≠ lb
-#         throw(DimensionMismatch("dot product arguments have lengths $la and $lb"))
-#     end
-#     return zero(T)
-# end
-# *(a::Transpose{T, <:AbstractMatrix{T}}, b::Zeros{T, 1}) where T<:Real = FillArrays.mult_zeros(a, b)
-
 const UpperOrAdjLower{T} = Union{
     UpperTriangular{T, <:ABM{T}},
     AdjOrTrans{T, <:LowerTriangular{T, <:ABM{T}}},

--- a/src/util/toeplitz.jl
+++ b/src/util/toeplitz.jl
@@ -1,5 +1,5 @@
 using ToeplitzMatrices
-import LinearAlgebra: Symmetric
+import LinearAlgebra: Symmetric, cholesky
 
 import Base: transpose, adjoint, copy
 import ToeplitzMatrices: Toeplitz
@@ -12,13 +12,40 @@ function copy(T::SymmetricToeplitz)
 end
 
 
+# """
+#     chol!(L::AbstractMatrix, T::SymmetricToeplitz)
+
+# Implementation adapted from "On the stability of the Bareiss and related
+# Toeplitz factorization algorithms", Bojanczyk et al, 1993.
+# """
+# function chol!(L::AbstractMatrix, T::SymmetricToeplitz)
+
+#     # Initialize.
+#     L[:, 1] .= T.vc ./ sqrt(T.vc[1])
+#     v = copy(L[:, 1])
+#     N = size(T, 1)
+
+#     # Iterate.
+#     @inbounds for n in 1:N-1
+#         sinθn = v[n + 1] / L[n, n]
+#         cosθn = sqrt(1 - sinθn^2)
+
+#         for n′ in n+1:N
+#             v[n′] = (v[n′] - sinθn * L[n′ - 1, n]) / cosθn
+#             L[n′, n + 1] = -sinθn * v[n′] + cosθn * L[n′ - 1, n]
+#         end
+#     end
+#     return UpperTriangular(L')
+# end
+# chol(T::SymmetricToeplitz) = chol!(Matrix{eltype(T)}(size(T, 1), size(T, 1)), T)
+
 """
-    chol!(L::AbstractMatrix, T::SymmetricToeplitz)
+    cholesky(T::SymmetricToeplitz)
 
 Implementation adapted from "On the stability of the Bareiss and related
 Toeplitz factorization algorithms", Bojanczyk et al, 1993.
 """
-function chol!(L::AbstractMatrix, T::SymmetricToeplitz)
+function cholesky!(L::AbstractMatrix, T::SymmetricToeplitz)
 
     # Initialize.
     L[:, 1] .= T.vc ./ sqrt(T.vc[1])
@@ -35,9 +62,11 @@ function chol!(L::AbstractMatrix, T::SymmetricToeplitz)
             L[n′, n + 1] = -sinθn * v[n′] + cosθn * L[n′ - 1, n]
         end
     end
-    return UpperTriangular(L')
+    return Cholesky(L, 'L', 0) 
 end
-chol(T::SymmetricToeplitz) = chol!(Matrix{eltype(T)}(size(T, 1), size(T, 1)), T)
+function cholesky(T::SymmetricToeplitz)
+    return cholesky!(Matrix{eltype(T)}(undef, size(T, 1), size(T, 1)), T)
+end
 
 function +(T::SymmetricToeplitz, u::UniformScaling)
     Tu = copy(T)

--- a/src/util/toeplitz.jl
+++ b/src/util/toeplitz.jl
@@ -11,34 +11,6 @@ function copy(T::SymmetricToeplitz)
     return SymmetricToeplitz(copy(T.vc), copy(T.vcvr_dft), copy(T.tmp), T.dft)
 end
 
-
-# """
-#     chol!(L::AbstractMatrix, T::SymmetricToeplitz)
-
-# Implementation adapted from "On the stability of the Bareiss and related
-# Toeplitz factorization algorithms", Bojanczyk et al, 1993.
-# """
-# function chol!(L::AbstractMatrix, T::SymmetricToeplitz)
-
-#     # Initialize.
-#     L[:, 1] .= T.vc ./ sqrt(T.vc[1])
-#     v = copy(L[:, 1])
-#     N = size(T, 1)
-
-#     # Iterate.
-#     @inbounds for n in 1:N-1
-#         sinθn = v[n + 1] / L[n, n]
-#         cosθn = sqrt(1 - sinθn^2)
-
-#         for n′ in n+1:N
-#             v[n′] = (v[n′] - sinθn * L[n′ - 1, n]) / cosθn
-#             L[n′, n + 1] = -sinθn * v[n′] + cosθn * L[n′ - 1, n]
-#         end
-#     end
-#     return UpperTriangular(L')
-# end
-# chol(T::SymmetricToeplitz) = chol!(Matrix{eltype(T)}(size(T, 1), size(T, 1)), T)
-
 """
     cholesky(T::SymmetricToeplitz)
 

--- a/src/util/toeplitz.jl
+++ b/src/util/toeplitz.jl
@@ -1,5 +1,5 @@
 using ToeplitzMatrices
-import LinearAlgebra: Symmetric, cholesky
+import LinearAlgebra: Symmetric, cholesky, *, mul!
 
 import Base: transpose, adjoint, copy
 import ToeplitzMatrices: Toeplitz
@@ -56,3 +56,23 @@ adjoint(T::SymmetricToeplitz) = T
 @inline LinearAlgebra.Symmetric(T::SymmetricToeplitz) = T
 
 Toeplitz(vc::AbstractVector, vr::AbstractVector) = Toeplitz(Vector(vc), Vector(vr))
+
+# """
+#     mul!(C::Matrix, A::AbstractToeplitz, B::AbstractToeplitz)
+
+# `O(prod(size(C)))` matrix multiplication for Toeplitz matrices. Follows from a skeleton of
+# an algorithm on stackoverflow:
+# https://stackoverflow.com/questions/15889521/product-of-two-toeplitz-matrices
+# """
+# function mul!(C::Matrix, A::AbstractToeplitz, B::AbstractToeplitz)
+#     for q in 1:size(C, 2)
+#         for p in 1:size(C, 1)
+#             C[p, q]
+#         end
+#     end
+#     return C
+# end
+
+# # function *(A::AbstractToeplitz, B::AbstractToeplitz)
+
+# # end

--- a/test/mean_and_kernel/kernel.jl
+++ b/test/mean_and_kernel/kernel.jl
@@ -81,6 +81,13 @@ struct FooKernel <: CrossKernel end
         kernel_tests(EQ(), BlockData([x0, x0]), BlockData([x1, x1]), BlockData([x2, x2]))
         kernel_tests(EQ(), BlockData([X0, X0]), BlockData([X1, X1]), BlockData([X2, X2]))
 
+        # Tests for Exponential.
+        @test isstationary(EQ())
+        @test size(Exponential(), 1) == Inf && size(Exponential(), 2) == Inf
+        @test size(Exponential()) == (Inf, Inf)
+        kernel_tests(Exponential(), x0, x1, x2)
+        kernel_tests(EQ(), BlockData([x0, x0]), BlockData([x1, x1]), BlockData([x2, x2]))
+
         # Tests for Linear.
         @test !isstationary(Linear)
         a, b = Linear(randn(rng)), Linear(randn(rng))

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -40,7 +40,7 @@ using Stheno, Test, Random, LinearAlgebra, Statistics
         include("linops/conditioning.jl")
     end
 
-    # @testset "integration" begin
-    #     include("util/toeplitz_integration.jl")
-    # end
+    @testset "integration" begin
+        include("util/toeplitz_integration.jl")
+    end
 end

--- a/test/util/toeplitz_integration.jl
+++ b/test/util/toeplitz_integration.jl
@@ -1,5 +1,5 @@
 using Stheno
-using Stheno: @model
+using Stheno: @model, LazyPDMat
 using ToeplitzMatrices: SymmetricToeplitz
 
 @testset "Toeplitz Integration" begin
@@ -35,7 +35,7 @@ fb_xl = BlockGP([f(xl), y(xl)])
 fb_x = BlockGP([f(x), y(x)])
 
 
-using Stheno: unbox
+using Stheno: unbox, chol
 Σl = unbox(cov(fb_xl)) + 1e-6I;
 U = chol(Σl);
 


### PR DESCRIPTION
Updates Toeplitz matrix functionality for stationary GPs with regularly spaced inputs for 1.0.

Also adds the Exponential kernel back in because I happened to need it.