### PR TITLE
Add addition and constant initialisation for GPs

### DIFF
--- a/src/gp/gp.jl
+++ b/src/gp/gp.jl
@@ -22,11 +22,19 @@ struct GP{Tμ<:MeanFunction, Tk<:Kernel} <: AbstractGaussianProcess
     GP{Tμ, Tk}(μ::Tμ, k::Tk, gpc::GPC) where {Tμ, Tk} = GP{Tμ, Tk}(nothing, μ, k, gpc)
 end
 GP(μ::Tμ, k::Tk, gpc::GPC) where {Tμ, Tk} = GP{Tμ, Tk}(μ, k, gpc)
-function GP(m::Real, k::Kernel, gpc::GPC)
+function GP(m::T, k::Kernel, gpc::GPC) where T<:Real
     if isfinite(length(k))
-        return GP(FiniteMean(ConstantMean(m), eachindex(k)), k, gpc)
+        if iszero(m)
+            return GP(zero(EmpiricalMean(Zeros(length(k)))), k, gpc)
+        else
+            return GP(FiniteMean(ConstantMean(m), eachindex(k)), k, gpc)
+        end
     else
-        return GP(ConstantMean(m), k, gpc)
+        if iszero(m)
+            return GP(zero(ConstantMean(m)), k, gpc)
+        else
+            return GP(ConstantMean(m), k, gpc)
+        end
     end
 end
 GP(k::Kernel, gpc::GPC) = GP(ZeroMean{Float64}(), k, gpc)

--- a/src/gp/gp.jl
+++ b/src/gp/gp.jl
@@ -22,7 +22,13 @@ struct GP{Tμ<:MeanFunction, Tk<:Kernel} <: AbstractGaussianProcess
     GP{Tμ, Tk}(μ::Tμ, k::Tk, gpc::GPC) where {Tμ, Tk} = GP{Tμ, Tk}(nothing, μ, k, gpc)
 end
 GP(μ::Tμ, k::Tk, gpc::GPC) where {Tμ, Tk} = GP{Tμ, Tk}(μ, k, gpc)
-GP(m::Real, k::Kernel, gpc::GPC) = GP(ConstantMean(m), k, gpc)
+function GP(m::Real, k::Kernel, gpc::GPC)
+    if isfinite(length(k))
+        return GP(FiniteMean(ConstantMean(m), eachindex(k)), k, gpc)
+    else
+        return GP(ConstantMean(m), k, gpc)
+    end
+end
 GP(k::Kernel, gpc::GPC) = GP(ZeroMean{Float64}(), k, gpc)
 function GP(args...)
     μ, k, gpc = μ_p′(args...), k_p′(args...), get_check_gpc(args...)

--- a/src/gp/gp.jl
+++ b/src/gp/gp.jl
@@ -21,22 +21,25 @@ struct GP{Tμ<:MeanFunction, Tk<:Kernel} <: AbstractGaussianProcess
     end
     GP{Tμ, Tk}(μ::Tμ, k::Tk, gpc::GPC) where {Tμ, Tk} = GP{Tμ, Tk}(nothing, μ, k, gpc)
 end
-GP(μ::Tμ, k::Tk, gpc::GPC) where {Tμ, Tk} = GP{Tμ, Tk}(μ, k, gpc)
-function GP(m::T, k::Kernel, gpc::GPC) where T<:Real
+GP(μ::Tμ, k::Tk, gpc::GPC) where {Tμ<:MeanFunction, Tk<:Kernel} = GP{Tμ, Tk}(μ, k, gpc)
+
+# GP initialised with a constant mean. Zero is specially handled.
+function GP(m::Real, k::Kernel, gpc::GPC)
     if isfinite(length(k))
         if iszero(m)
-            return GP(zero(EmpiricalMean(Zeros(length(k)))), k, gpc)
+            return GP(zero(EmpiricalMean(Zeros(length(k)))), k, gpc)  # hack
         else
             return GP(FiniteMean(ConstantMean(m), eachindex(k)), k, gpc)
         end
     else
         if iszero(m)
-            return GP(zero(ConstantMean(m)), k, gpc)
+            return GP(zero(ConstantMean(m)), k, gpc)  # hack
         else
             return GP(ConstantMean(m), k, gpc)
         end
     end
 end
+GP(m, k::Kernel, gpc::GPC) = GP(CustomMean(m), k, gpc)
 GP(k::Kernel, gpc::GPC) = GP(ZeroMean{Float64}(), k, gpc)
 function GP(args...)
     μ, k, gpc = μ_p′(args...), k_p′(args...), get_check_gpc(args...)

--- a/src/gp/gp.jl
+++ b/src/gp/gp.jl
@@ -22,6 +22,7 @@ struct GP{Tμ<:MeanFunction, Tk<:Kernel} <: AbstractGaussianProcess
     GP{Tμ, Tk}(μ::Tμ, k::Tk, gpc::GPC) where {Tμ, Tk} = GP{Tμ, Tk}(nothing, μ, k, gpc)
 end
 GP(μ::Tμ, k::Tk, gpc::GPC) where {Tμ, Tk} = GP{Tμ, Tk}(μ, k, gpc)
+GP(m::Real, k::Kernel, gpc::GPC) = GP(ConstantMean(m), k, gpc)
 GP(k::Kernel, gpc::GPC) = GP(ZeroMean{Float64}(), k, gpc)
 function GP(args...)
     μ, k, gpc = μ_p′(args...), k_p′(args...), get_check_gpc(args...)

--- a/src/linops/addition.jl
+++ b/src/linops/addition.jl
@@ -29,10 +29,10 @@ k_pp′(fp::GP, ::typeof(+), fa, fb) = kernel(fp, fa) + kernel(fp, fb)
 k_p′p(::typeof(+), fa, fb, fp::GP) = kernel(fa, fp) + kernel(fb, fp)
 
 """
-    +(c::Real, f::GP)
-    +(f::GP, c::Real)
+    +(c, f::GP)
+    +(f::GP, c)
 
-Adding a constant to a GP just shifts the mean.
+Adding a deterministic quantity to a GP just shifts the mean.
 """
-+(c::T, f::GP) where T<:Real = GP(c, zero(kernel(f)), f.gpc) + f
-+(f::GP, c::T) where T<:Real = f + GP(c, zero(kernel(f)), f.gpc)
++(c, f::GP) = GP(c, zero(kernel(f)), f.gpc) + f
++(f::GP, c) = f + GP(c, zero(kernel(f)), f.gpc)

--- a/src/linops/addition.jl
+++ b/src/linops/addition.jl
@@ -27,3 +27,12 @@ function k_p′(::typeof(+), fa, fb)
 end
 k_pp′(fp::GP, ::typeof(+), fa, fb) = kernel(fp, fa) + kernel(fp, fb)
 k_p′p(::typeof(+), fa, fb, fp::GP) = kernel(fa, fp) + kernel(fb, fp)
+
+"""
+    +(c::Real, f::GP)
+    +(f::GP, c::Real)
+
+Adding a constant to a GP just shifts the mean.
+"""
++(c::T, f::GP) where T<:Real = GP(c, ZeroKernel{T}(), f.gpc) + f
++(f::GP, c::T) where T<:Real = f + GP(c, ZeroKernel{T}(), f.gpc)

--- a/src/linops/addition.jl
+++ b/src/linops/addition.jl
@@ -1,4 +1,4 @@
-import Base: +
+import Base: +, -
 
 """
     +(fa::GP, fb::GP)
@@ -36,3 +36,9 @@ Adding a deterministic quantity to a GP just shifts the mean.
 """
 +(c, f::GP) = GP(c, zero(kernel(f)), f.gpc) + f
 +(f::GP, c) = f + GP(c, zero(kernel(f)), f.gpc)
+
+# Define negation in terms of other operations.
+-(f::GP) = -1 * f
+-(f::GP, c) = f + (-c)
+-(c, f::GP) = c + (-f)
+-(f::GP, g::GP) = f + (-g)

--- a/src/linops/addition.jl
+++ b/src/linops/addition.jl
@@ -34,5 +34,5 @@ k_p′p(::typeof(+), fa, fb, fp::GP) = kernel(fa, fp) + kernel(fb, fp)
 
 Adding a constant to a GP just shifts the mean.
 """
-+(c::T, f::GP) where T<:Real = GP(c, ZeroKernel{T}(), f.gpc) + f
-+(f::GP, c::T) where T<:Real = f + GP(c, ZeroKernel{T}(), f.gpc)
++(c::T, f::GP) where T<:Real = GP(c, zero(kernel(f)), f.gpc) + f
++(f::GP, c::T) where T<:Real = f + GP(c, zero(kernel(f)), f.gpc)

--- a/src/mean_and_kernel/mean.jl
+++ b/src/mean_and_kernel/mean.jl
@@ -48,6 +48,8 @@ struct ZeroMean{T<:Real} <: BaseMeanFunction end
 ==(::ZeroMean, ::ZeroMean) = true
 
 const ZM = ZeroMean{Float64}
+zero(::Type{<:MeanFunction}, N::Int) = FiniteZeroMean(1:N)
+zero(::Type{<:MeanFunction}) = ZeroMean{Float64}()
 zero(μ::MeanFunction) = length(μ) < Inf ? FiniteZeroMean(eachindex(μ)) : ZM()
 
 """

--- a/test/gp/block_gp.jl
+++ b/test/gp/block_gp.jl
@@ -1,5 +1,5 @@
 using Random, LinearAlgebra
-using Stheno: BlockGP
+using Stheno: BlockGP, getblock, LazyPDMat
 using Distributions: MvNormal, PDMat
 
 @testset "block_gp" begin

--- a/test/gp/gp.jl
+++ b/test/gp/gp.jl
@@ -16,7 +16,10 @@
     let
         m = 5.1
         @test mean(GP(m, EQ(), GPC())) == ConstantMean(m)
+        @test mean(GP(zero(m), EQ(), GPC())) === ZeroMean{typeof(m)}()
         @test mean_vec(GP(m, FiniteKernel(EQ(), randn(10)), GPC())) == fill(m, 10)
+        @test mean(GP(zero(m), FiniteKernel(EQ(), randn(10)), GPC())) ==
+            zero(FiniteMean(ConstantMean(m), randn(10)))
     end
 
     # Test the creation of indepenent GPs.

--- a/test/gp/gp.jl
+++ b/test/gp/gp.jl
@@ -16,6 +16,7 @@
     let
         m = 5.1
         @test mean(GP(m, EQ(), GPC())) == ConstantMean(m)
+        @test mean_vec(GP(m, FiniteKernel(EQ(), randn(10)), GPC())) == fill(m, 10)
     end
 
     # Test the creation of indepenent GPs.

--- a/test/gp/gp.jl
+++ b/test/gp/gp.jl
@@ -20,6 +20,9 @@
         @test mean_vec(GP(m, FiniteKernel(EQ(), randn(10)), GPC())) == fill(m, 10)
         @test mean(GP(zero(m), FiniteKernel(EQ(), randn(10)), GPC())) ==
             zero(FiniteMean(ConstantMean(m), randn(10)))
+
+        x = randn(10)
+        @test map(mean(GP(sin, EQ(), GPC())), x) == sin.(x)
     end
 
     # Test the creation of indepenent GPs.

--- a/test/gp/gp.jl
+++ b/test/gp/gp.jl
@@ -12,6 +12,12 @@
     #     @test Stheno.permutedims(x) == x'
     # end
 
+    # Check various ways to construct a GP do what you would expect.
+    let
+        m = 5.1
+        @test mean(GP(m, EQ(), GPC())) == ConstantMean(m)
+    end
+
     # Test the creation of indepenent GPs.
     let rng = MersenneTwister(123456)
 

--- a/test/linops/addition.jl
+++ b/test/linops/addition.jl
@@ -43,4 +43,13 @@
         @test mean_vec((f2 + fj2)(BlockData([X, X′]))) ==
             BlockData([mean_vec((f2 + f2)(X)), mean_vec((f2 + f1)(X′))])
     end
+
+    # Check that adding a constant to a GP yields a GP with a shifted mean.
+    let
+        rng, N, D = MersenneTwister(123456), 5, 6, 2
+        X = ColsAreObs(randn(rng, D, N))
+        c, f = randn(rng), GP(5.0, EQ(), GPC())
+        @test map(mean(f + c), X) == map(mean(f), X) .+ c
+        @test map(mean(c + f), X) == c .+ map(mean(f), X)
+    end
 end

--- a/test/linops/addition.jl
+++ b/test/linops/addition.jl
@@ -1,3 +1,5 @@
+using Stheno: pairwise
+
 @testset "addition" begin
     let
         rng, N, N′, D, gpc = MersenneTwister(123456), 5, 6, 2, GPC()
@@ -51,8 +53,16 @@
         c, f = randn(rng), GP(5.0, EQ(), GPC())
         @test map(mean(f + c), X) == map(mean(f), X) .+ c
         @test map(mean(c + f), X) == c .+ map(mean(f), X)
+        @test pairwise(kernel(f + c), X) == pairwise(kernel(f), X)
+        @test pairwise(kernel(c + f), X) == pairwise(kernel(f), X)
 
         g = f(randn(rng, 10))
         @test mean_vec(g + c) == mean_vec(g) .+ c
+
+        x = randn(rng, N + D)
+        @test map(mean(f + sin), x) == map(mean(f), x) + map(sin, x)
+        @test map(mean(sin + f), x) == map(sin, x) + map(mean(f), x)
+        @test pairwise(kernel(f + sin), x) == pairwise(kernel(f), x)
+        @test pairwise(kernel(sin + f), x) == pairwise(kernel(f), x)
     end
 end

--- a/test/linops/addition.jl
+++ b/test/linops/addition.jl
@@ -56,6 +56,11 @@ using Stheno: pairwise
         @test pairwise(kernel(f + c), X) == pairwise(kernel(f), X)
         @test pairwise(kernel(c + f), X) == pairwise(kernel(f), X)
 
+        @test map(mean(f - c), X) == map(mean(f), X) .- c
+        @test map(mean(c - f), X) == c .- map(mean(f), X)
+        @test pairwise(kernel(f - c), X) == pairwise(kernel(f), X)
+        @test pairwise(kernel(c - f), X) == pairwise(kernel(f), X)
+
         g = f(randn(rng, 10))
         @test mean_vec(g + c) == mean_vec(g) .+ c
 

--- a/test/linops/addition.jl
+++ b/test/linops/addition.jl
@@ -51,5 +51,8 @@
         c, f = randn(rng), GP(5.0, EQ(), GPC())
         @test map(mean(f + c), X) == map(mean(f), X) .+ c
         @test map(mean(c + f), X) == c .+ map(mean(f), X)
+
+        g = f(randn(rng, 10))
+        @test mean_vec(g + c) == mean_vec(g) .+ c
     end
 end


### PR DESCRIPTION
Lets you write things like
```julia
f = GP(5.0, EQ())
```
and
```julia
f = GP(EQ())
f + 5.0
```
and have sensible things happen. TODO:

- [x] Subtraction of constants.
- [x] Addition / subtraction of deterministic functions.
- [x] Appropriate behaviour for `iszero`-related things.
- [x] Appropriate behaviour in the finite-case.