### PR TITLE
Remove Iterators

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -2,7 +2,6 @@ julia 1.0.0
 Distances
 BlockArrays 0.4.1 0.5.0
 FillArrays 0.1.0
-IterTools
 Distributions
 ToeplitzMatrices
 MacroTools

--- a/src/Stheno.jl
+++ b/src/Stheno.jl
@@ -1,6 +1,6 @@
 module Stheno
 
-    using Distributions, Distances, BlockArrays, FillArrays, IterTools, Statistics, Random
+    using Distributions, Distances, BlockArrays, FillArrays, Statistics, Random
 
     const AV{T} = AbstractVector{T}
     const AM{T} = AbstractMatrix{T}

--- a/src/mean_and_kernel/kernel.jl
+++ b/src/mean_and_kernel/kernel.jl
@@ -1,10 +1,9 @@
-using IterTools, LinearAlgebra
+using LinearAlgebra
 import LinearAlgebra: AbstractMatrix
 import Base: +, *, ==, size, eachindex, print
 import Distances: pairwise
 export CrossKernel, Kernel, cov, xcov, EQ, RQ, Linear, Poly, Noise, Wiener, WienerVelocity,
     Exponential, ConstantKernel, isstationary, ZeroKernel
-using IterTools: product
 
 
 ############################# Define CrossKernels and Kernels ##############################

--- a/test/REQUIRE
+++ b/test/REQUIRE
@@ -1,3 +1,0 @@
-QuadGK
-Revise
-Iterators

--- a/test/test_util.jl
+++ b/test/test_util.jl
@@ -1,4 +1,4 @@
-using IterTools, BlockArrays, LinearAlgebra
+using BlockArrays, LinearAlgebra
 using Stheno: MeanFunction, Kernel, CrossKernel, AV, blocks, pairwise, LazyPDMat
 
 """


### PR DESCRIPTION
The dependency on the deprecated package Iterators causes test errors both locally on my computer and on [Travis](https://travis-ci.org/willtebbutt/Stheno.jl/jobs/449515077). It seems also the explicit dependencies on IterTools, Revise, and QuadGK can be dropped.