### PR TITLE
Time the tests for very basic debugging purposes

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -24,6 +24,7 @@ julia = ">=1.1.1"
 [extras]
 FiniteDifferences = "26cc04aa-876d-5657-8c51-4c34ba976000"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+TimerOutputs = "a759f4b9-e2f1-59dc-863e-4aeb61b1ea8f"
 
 [targets]
-test = ["FiniteDifferences", "Test"]
+test = ["FiniteDifferences", "Test", "TimerOutputs"]

--- a/test/composite/addition.jl
+++ b/test/composite/addition.jl
@@ -1,7 +1,7 @@
 using Stheno: GPC, EQ, Exp
 
-@testset "addition" begin
-    @testset "Correlated GPs" begin
+@timedtestset "addition" begin
+    @timedtestset "Correlated GPs" begin
         rng, N, N′, D, gpc = MersenneTwister(123456), 5, 6, 2, GPC()
         X, X′ = ColsAreObs(randn(rng, D, N)), ColsAreObs(randn(rng, D, N′))
         f1, f2 = GP(1, EQ(), gpc), GP(2, Exp(), gpc)
@@ -23,14 +23,14 @@ using Stheno: GPC, EQ, Exp
             @test cov(fa(X′), fp(X)) ≈ cov(fb(X′), fa(X)) + cov(fa(X′), fa(X))
         end
 
-        @testset "Consistency Tests" begin
+        @timedtestset "Consistency Tests" begin
             P, Q = 4, 3
             x0, x1, x2, x3 = randn(rng, P), randn(rng, Q), randn(rng, Q), randn(rng, P)
             abstractgp_interface_tests(f3, f1, x0, x1, x2, x3)
             abstractgp_interface_tests(f2 - f1, f1, x0, x1, x2, x3)
         end
     end
-    @testset "Verify mean / kernel numerically" begin
+    @timedtestset "Verify mean / kernel numerically" begin
         rng, N, D = MersenneTwister(123456), 5, 6
         X = ColsAreObs(randn(rng, D, N))
         c, f = randn(rng), GP(5, EQ(), GPC())
@@ -51,13 +51,13 @@ using Stheno: GPC, EQ, Exp
         @test cov((f + sin)(x)) == cov(f(x))
         @test cov((sin + f)(x)) == cov(f(x))
 
-        @testset "Consistency Tests" begin
+        @timedtestset "Consistency Tests" begin
             P, Q = 5, 3
             x0, x1, x2, x3 = randn(rng, P), randn(rng, Q), randn(rng, Q), randn(rng, P)
             abstractgp_interface_tests(c + f, f, x0, x1, x2, x3)
         end
     end
-    @testset "Standardised Tests (independent sum)" begin
+    @timedtestset "Standardised Tests (independent sum)" begin
         standard_1D_tests(
             MersenneTwister(123456),
             Dict(:l1=>0.5, :l2=>2.3),
@@ -72,7 +72,7 @@ using Stheno: GPC, EQ, Exp
             collect(range(-1.0, 0.5; length=3)),
         )
     end
-    @testset "Standardised Tests (correlated sum)" begin
+    @timedtestset "Standardised Tests (correlated sum)" begin
         standard_1D_tests(
             MersenneTwister(123456),
             Dict(:l1=>0.5, :l2=>2.3),

--- a/test/composite/approximate_conditioning.jl
+++ b/test/composite/approximate_conditioning.jl
@@ -3,15 +3,15 @@ using Stheno: GPC, optimal_q, ApproxObs
 
 # Test Titsias implementation by checking that it (approximately) recovers exact inference
 # when M = N and Z = X.
-@testset "Titsias" begin
-    @testset "optimal_q (single conditioning)" begin
-        @testset "σ²" begin
+@timedtestset "Titsias" begin
+    @timedtestset "optimal_q (single conditioning)" begin
+        @timedtestset "σ²" begin
             rng, N, σ², gpc = MersenneTwister(123456), 10, 1e-1, GPC()
             x = collect(range(-3.0, 3.0, length=N))
             f = GP(sin, EQ(), gpc)
 
             for σ² in [1e-2, 1e-1, 1e0, 1e1]
-                @testset "σ² = $σ²" begin
+                @timedtestset "σ² = $σ²" begin
                     y = rand(rng, f(x, σ²))
 
                     # Compute approximate posterior suff. stats.
@@ -26,7 +26,7 @@ using Stheno: GPC, optimal_q, ApproxObs
                 end
             end
         end
-        @testset "Diagonal" begin
+        @timedtestset "Diagonal" begin
             rng, N, gpc = MersenneTwister(123456), 11, GPC()
             x = collect(range(-3.0, 3.0, length=N))
             f = GP(sin, EQ(), gpc)
@@ -43,7 +43,7 @@ using Stheno: GPC, optimal_q, ApproxObs
             B = U' \ cov(f(x))
             @test Λ_ε.U ≈ cholesky(Symmetric(B * (Σ \ B') + I)).U
         end
-        @testset "Dense" begin
+        @timedtestset "Dense" begin
             rng, N, gpc = MersenneTwister(123456), 10, GPC()
             x = collect(range(-3.0, 3.0, length=N))
             f = GP(sin, EQ(), gpc)
@@ -62,7 +62,7 @@ using Stheno: GPC, optimal_q, ApproxObs
             @test Λ_ε.U ≈ cholesky(Symmetric(B * (cholesky(Σ) \ B') + I)).U
         end
     end
-    @testset "optimal_q (multiple conditioning)" begin
+    @timedtestset "optimal_q (multiple conditioning)" begin
         rng, N, N′, σ², gpc = MersenneTwister(123456), 5, 7, 1e-1, GPC()
         xx′ = collect(range(-3.0, stop=3.0; length=N + N′))
         idx = randperm(rng, length(xx′))[1:N]
@@ -82,7 +82,7 @@ using Stheno: GPC, optimal_q, ApproxObs
         @test U ≈ cholesky(cov(f(xx′))).U
         @test Λ_ε.U ≈ cholesky((U' \ cov(f(xx′))) * (U' \ cov(f(xx′)))' ./ σ² + I).U
 
-        @testset "multiple cond, multiple pseudo points" begin
+        @timedtestset "multiple cond, multiple pseudo points" begin
             z, z′ = randn(rng, 3), randn(rng, 2)
             zz′ = vcat(z, z′)
             u = ApproxObs(f(zz′), (f(x, σ²)←y, f(x′, σ²)←y′))
@@ -91,7 +91,7 @@ using Stheno: GPC, optimal_q, ApproxObs
             @test u.û.Λ.U ≈ u′.û.Λ.U
             @test u.U ≈ u′.U
         end
-        @testset "single cond, multiple pseudo points" begin
+        @timedtestset "single cond, multiple pseudo points" begin
             z, z′ = randn(rng, 3), randn(rng, 2)
             zz′ = vcat(z, z′)
             u = ApproxObs(f(zz′), f(x, σ²)←y)
@@ -101,7 +101,7 @@ using Stheno: GPC, optimal_q, ApproxObs
             @test u.U ≈ u′.U
         end
     end
-    @testset "Consistency Tests" begin
+    @timedtestset "Consistency Tests" begin
         rng, N, M, σ², gpc = MersenneTwister(123456), 5, 3, 1e-1, GPC()
         x = collect(range(-3.0, 3.0, length=N))
         z = randn(rng, M)
@@ -122,7 +122,7 @@ using Stheno: GPC, optimal_q, ApproxObs
         @test_throws ArgumentError Stheno.mean_vector(ỹ.û, randn(rng, P))
         @test_throws ArgumentError cov(ỹ.û, ApproxObs(f, z, m_ε, Λ_ε, U).û, x0, x1)
     end
-    @testset "accuracy tests" begin
+    @timedtestset "accuracy tests" begin
         rng, N, N′, Nz, σ², gpc = MersenneTwister(123456), 5, 3, 2, 1e-1, GPC()
         x = collect(range(-3.0, 3.0, length=N))
         x′ = collect(range(-3.0, 3.0, length=N′))
@@ -148,8 +148,8 @@ using Stheno: GPC, optimal_q, ApproxObs
         @test cov(f′(x′), g′(x)) ≈ cov(f′_approx(x′), g′_approx(x))
         @test cov(g′(x′), f′(x)) ≈ cov(g′_approx(x′), f′_approx(x))
 
-        @testset "Standardised Tests" begin
-            @testset "Dense Obs. Noise" begin
+        @timedtestset "Standardised Tests" begin
+            @timedtestset "Dense Obs. Noise" begin
                 # N_obs, M_obs = 11, 13
                 # x_obs = collect(range(-5.0, 5.0; length=N_obs))
                 # z_obs = collect(range(-5.0, 5.0; length=M_obs))
@@ -167,13 +167,13 @@ using Stheno: GPC, optimal_q, ApproxObs
                 #     17, 19,
                 # )
             end
-            @testset "Diagonal Obs. Noise" begin
+            @timedtestset "Diagonal Obs. Noise" begin
                 
             end
-            @testset "Isotropic Obs. Noise" begin
+            @timedtestset "Isotropic Obs. Noise" begin
                 
             end
-            @testset "BlockDiagonal Obs. Noise" begin
+            @timedtestset "BlockDiagonal Obs. Noise" begin
                 
             end
         end 

--- a/test/composite/compose.jl
+++ b/test/composite/compose.jl
@@ -1,6 +1,6 @@
 using Stheno: GPC, EQ, Exp
 
-@testset "compose" begin
+@timedtestset "compose" begin
     rng, N, N′, gpc = MersenneTwister(123456), 5, 3, GPC()
     x, x′ = randn(rng, N), randn(rng, N′)
     f, g, h = GP(sin, EQ(), gpc), cos, GP(exp, Exp(), gpc)
@@ -19,7 +19,7 @@ using Stheno: GPC, EQ, Exp
     @test cov(fg(x), h(x′)) == zeros(length(x), length(x′))
     @test cov(h(x), fg(x′)) == zeros(length(x), length(x′))
 
-    @testset "Consistency Tests" begin
+    @timedtestset "Consistency Tests" begin
         P, Q = 4, 3
         x0, x1, x2, x3 = randn(rng, P), randn(rng, Q), randn(rng, Q), randn(rng, P)
         abstractgp_interface_tests(fg, f, x0, x1, x2, x3)
@@ -28,7 +28,7 @@ using Stheno: GPC, EQ, Exp
         # f = GP(EQ(), GPC())
         # abstractgp_interface_tests(periodic(f, 0.1), f, x0, x1, x2, x3)
     end
-    @testset "Diff Tests" begin
+    @timedtestset "Diff Tests" begin
         standard_1D_tests(
             MersenneTwister(123456),
             Dict(:σ=>0.5),

--- a/test/composite/conditioning.jl
+++ b/test/composite/conditioning.jl
@@ -6,8 +6,8 @@ function abs_rel_errs(x, y)
     return [δ δ ./ vec(y)]
 end
 
-@testset "conditioning" begin
-    @testset "Observation" begin
+@timedtestset "conditioning" begin
+    @timedtestset "Observation" begin
         rng, N, N′, D = MersenneTwister(123456), 5, 6, 2
         X, X′ = ColsAreObs(randn(rng, D, N)), ColsAreObs(randn(rng, D, N′))
         y, y′ = randn(rng, N), randn(rng, N′)
@@ -22,7 +22,7 @@ end
         c = merge((c1, c2))
         @test get_y(c) == BlockVector([y, y′])
     end
-    @testset "condition once" begin
+    @timedtestset "condition once" begin
         rng, N, N′, D = MersenneTwister(123456), 10, 3, 2
         x = collect(range(-3.0, stop=3.0, length=N))
         f = GP(1, EQ(), GPC())
@@ -34,7 +34,7 @@ end
         @test maximum(abs.(mean(f′(x)) - y)) < 1e-3
         @test all(abs.(cov(f′(x))) .< 1e-6)
     end
-    @testset "condition repeatedly" begin
+    @timedtestset "condition repeatedly" begin
         rng, N, N′ = MersenneTwister(123456), 5, 7
         xx′ = collect(range(-3.0, stop=3.0, length=N+N′))
         idx = randperm(rng, length(xx′))[1:N]
@@ -57,7 +57,7 @@ end
         @test cov(f′(xx′)) ≈ cov(f′2(xx′))
         @test cov(f′(x), f′(x′)) ≈ cov(f′2(x), f′2(x′))
     end
-    @testset "Consistency Tests" begin
+    @timedtestset "Consistency Tests" begin
         rng, N, P, Q = MersenneTwister(123456), 11, 5, 3
         f = GP(sin, EQ(), GPC())
         x = collect(range(-1.0, 1.0; length=N))
@@ -81,7 +81,7 @@ end
         f′, f′′ = (f, f) | (f(x, 1e-9)←y, f(x′, 1e-9)←y′)
         abstractgp_interface_tests(f′, f′′, x0, x1, x2, x3)
     end
-    @testset "Diff Tests" begin
+    @timedtestset "Diff Tests" begin
         rng, N, P, Q = MersenneTwister(123456), 11, 5, 3
         x_obs, A_obs = collect(range(-5.0, 5.0; length=N)), randn(rng, N, N)
         y_obs = rand(rng, GP(sin, EQ(), GPC())(x_obs, _to_psd(A_obs)))
@@ -97,7 +97,7 @@ end
             collect(range(-4.0, 5.0; length=Q)),
         )
     end
-    @testset "Conditioning with cross" begin
+    @timedtestset "Conditioning with cross" begin
         rng, N, N′, σ² = MersenneTwister(123456), 3, 7, 1.0
         xx′ = collect(range(-3.0, stop=3.0, length=N+N′))
         xp = collect(range(-4.0, stop=4.0, length=N+N′+10))

--- a/test/composite/cross.jl
+++ b/test/composite/cross.jl
@@ -1,7 +1,7 @@
 using Stheno: BlockData, GPC, cross
 
-@testset "cross" begin
-    @testset "Correctness tests" begin
+@timedtestset "cross" begin
+    @timedtestset "Correctness tests" begin
         rng, P, Q, gpc = MersenneTwister(123456), 2, 3, GPC()
 
         f1 = GP(sin, EQ(), gpc)
@@ -45,7 +45,7 @@ using Stheno: BlockData, GPC, cross
         @test cov(f3(x3), f4(x4)) == cov(f3(x3), f1(x1))
         @test cov(f5(x5), f3(x3)) == cov(f2(x2), f3(x3))
 
-        @testset "rand, logpdf, elbo" begin
+        @timedtestset "rand, logpdf, elbo" begin
 
             # Single-sample rand
             y1, y2 = rand([f1(x1), f2(x2)])
@@ -72,7 +72,7 @@ using Stheno: BlockData, GPC, cross
             @test elbo(f1(x1, 1e-3), y1, [f1(x1), f2(x2)]) ≈ logpdf(f1(x1, 1e-3), y1)
         end
     end
-    @testset "Standardised Tests" begin
+    @timedtestset "Standardised Tests" begin
         rng, P, Q = MersenneTwister(123456), 3, 5
         x0_1, x0_2 = collect(range(-1.0, 1.0; length=P)), collect(range(2.0, 4.0; length=P))
         x1_1, x1_2 = randn(rng, Q), randn(rng, Q)
@@ -100,7 +100,7 @@ using Stheno: BlockData, GPC, cross
         #     BlockData([z1, z2]),
         # )
     end
-    @testset "finites_to_block" begin
+    @timedtestset "finites_to_block" begin
         rng, P, Q = MersenneTwister(123456), 3, 5
         xp, xq = randn(rng, P), randn(rng, Q)
         gpc = GPC()

--- a/test/composite/indexing.jl
+++ b/test/composite/indexing.jl
@@ -1,14 +1,14 @@
 using Random, LinearAlgebra
 using Stheno: GPC
 
-@testset "indexing" begin
-    @testset "no noise" begin
+@timedtestset "indexing" begin
+    @timedtestset "no noise" begin
         f, x = GP(EQ(), GPC()), randn(17)
         fx = f(x)
         @test mean(fx) == mean_vector(f, x)
         @test cov(fx) == cov(f, x)
     end
-    @testset "(Symmetric) Matrix-valued noise" begin
+    @timedtestset "(Symmetric) Matrix-valued noise" begin
         rng, N = MersenneTwister(123456), 13
         f, x, A = GP(EQ(), GPC()), randn(rng, N), randn(rng, N, N)
         C = Symmetric(A * A' + I)
@@ -16,14 +16,14 @@ using Stheno: GPC
         @test mean(fx) == mean_vector(f, x)
         @test cov(fx) == cov(f, x) + C
     end
-    @testset "Vector-valued noise" begin
+    @timedtestset "Vector-valued noise" begin
         rng, N = MersenneTwister(123456), 11
         f, x, a = GP(EQ(), GPC()), randn(rng, N), exp.(randn(rng, N))
         fx = f(x, a)
         @test mean(fx) == mean_vector(f, x)
         @test cov(fx) == cov(f, x) + Diagonal(a)
     end
-    @testset "Real-valued noise" begin
+    @timedtestset "Real-valued noise" begin
         rng, N = MersenneTwister(123456), 13
         f, x, σ² = GP(EQ(), GPC()), randn(rng, N), exp(randn(rng))
         fx = f(x, σ²)

--- a/test/composite/product.jl
+++ b/test/composite/product.jl
@@ -1,12 +1,12 @@
 using Stheno: GPC, EQ
 
-@testset "product" begin
-    @testset "GP mul errors" begin
+@timedtestset "product" begin
+    @timedtestset "GP mul errors" begin
         gpc = GPC()
         f1, f2 = GP(EQ(), gpc), GP(EQ(), gpc)
         @test_throws ArgumentError f1 * f2
     end
-    @testset "multiply by constant" begin
+    @timedtestset "multiply by constant" begin
         rng, N, N′, D = MersenneTwister(123456), 3, 5, 2
         X, X′ = ColsAreObs(randn(rng, D, N)), ColsAreObs(randn(rng, D, N′))
         g1, c, c′ = GP(1, EQ(), GPC()), -4.3, 2.1
@@ -44,7 +44,7 @@ using Stheno: GPC, EQ
         @test cov(g2(X), g4′(X′)) ≈ (c * c′^3) .* cov(g1(X), g1(X′))
         @test cov(g4(X), g2′(X′)) ≈ (c^3 * c′) .* cov(g1(X), g1(X′))
 
-        @testset "Consistency Tests" begin
+        @timedtestset "Consistency Tests" begin
             rng, P, Q = MersenneTwister(123456), 3, 5
             x0 = collect(range(-1.0, 1.0; length=P))
             x1 = collect(range(-0.5, 1.5; length=Q))
@@ -55,7 +55,7 @@ using Stheno: GPC, EQ
             f2 = 5 * f1
             abstractgp_interface_tests(f2, f1, x0, x1, x2, x3)
         end
-        @testset "Diff Tests" begin
+        @timedtestset "Diff Tests" begin
             standard_1D_tests(
                 MersenneTwister(123456),
                 Dict(:σ=>2.3),
@@ -67,7 +67,7 @@ using Stheno: GPC, EQ
             )
         end
     end
-    @testset "multiply by function" begin
+    @timedtestset "multiply by function" begin
         rng, N, N′, D = MersenneTwister(123456), 3, 5, 2
         X, X′ = ColsAreObs(randn(rng, D, N)), ColsAreObs(randn(rng, D, N′))
         g1, f, f′ = GP(1, EQ(), GPC()), x->sum(sin, x), x->sum(cos, x)
@@ -111,7 +111,7 @@ using Stheno: GPC, EQ
         @test cov(g2(X), g4′(X′)) ≈ fX .* cov(g1(X), g1(X′)) .* (f′X′').^3
         @test cov(g4(X), g2′(X′)) ≈ fX.^3 .* cov(g1(X), g1(X′)) .* (f′X′')
 
-        @testset "Consistency Tests" begin
+        @timedtestset "Consistency Tests" begin
             rng, P, Q = MersenneTwister(123456), 3, 5
             x0 = collect(range(-1.0, 1.0; length=P))
             x1 = collect(range(-0.5, 1.5; length=Q))
@@ -122,7 +122,7 @@ using Stheno: GPC, EQ
             f2 = sin * f1
             abstractgp_interface_tests(f2, f1, x0, x1, x2, x3)
         end
-        @testset "Diff Tests" begin
+        @timedtestset "Diff Tests" begin
             standard_1D_tests(
                 MersenneTwister(123456),
                 Dict(:σ=>2.3, :c=>1.3),

--- a/test/gp/gp.jl
+++ b/test/gp/gp.jl
@@ -1,10 +1,10 @@
 using Stheno: GPC, ZeroMean, ConstMean, CustomMean, ZeroKernel
 using Stheno: EQ, Exp
 
-@testset "gp" begin
+@timedtestset "gp" begin
 
     # Ensure that basic functionality works as expected.
-    @testset "GP" begin
+    @timedtestset "GP" begin
         rng, gpc, N, N′ = MersenneTwister(123456), GPC(), 5, 6
         m, k = CustomMean(sin), EQ()
         f = GP(m, k, gpc)
@@ -20,14 +20,14 @@ using Stheno: EQ, Exp
     end
 
     # Check that mean-function specialisations work as expected.
-    @testset "sugar" begin
+    @timedtestset "sugar" begin
         m = 5.1
         @test GP(5, EQ(), GPC()).m isa ConstMean
         @test GP(EQ(), GPC()).m isa ZeroMean
     end
 
     # Test the creation of indepenent GPs.
-    @testset "independent GPs" begin
+    @timedtestset "independent GPs" begin
         rng, N, N′ = MersenneTwister(123456), 5, 6
         x, x′ = randn(rng, N), randn(rng, N′)
 

--- a/test/gp/kernel.jl
+++ b/test/gp/kernel.jl
@@ -2,9 +2,9 @@ using Stheno: ZeroKernel, OneKernel, ConstKernel, CustomMean, pw, Stretched
 using Stheno: EQ, Exp, Linear, Noise, PerEQ, Matern32, Matern52, RQ, Product, stretch
 using LinearAlgebra
 
-@testset "kernel" begin
+@timedtestset "kernel" begin
 
-    @testset "base kernels" begin
+    @timedtestset "base kernels" begin
         rng, N, N′, D = MersenneTwister(123456), 5, 6, 2
         x0 = collect(range(-2.0, 2.0; length=N)) .+ 1e-3 .* randn(rng, N)
         x1 = collect(range(-1.7, 2.3; length=N)) .+ 1e-3 .* randn(rng, N)
@@ -19,66 +19,66 @@ using LinearAlgebra
 
         ȳ, Ȳ, Ȳ_sq = randn(rng, N), randn(rng, N, N′), randn(rng, N, N)
 
-        @testset "ZeroKernel" begin
+        @timedtestset "ZeroKernel" begin
             differentiable_kernel_tests(ZeroKernel(), ȳ, Ȳ, Ȳ_sq, x0, x1, x2)
             differentiable_kernel_tests(ZeroKernel(), ȳ, Ȳ, Ȳ_sq, X0, X1, X2)
         end
 
-        @testset "OneKernel" begin
+        @timedtestset "OneKernel" begin
             differentiable_kernel_tests(OneKernel(), ȳ, Ȳ, Ȳ_sq, x0, x1, x2)
             differentiable_kernel_tests(OneKernel(), ȳ, Ȳ, Ȳ_sq, X0, X1, X2)
         end
 
-        @testset "ConstKernel" begin
+        @timedtestset "ConstKernel" begin
             @test ew(ConstKernel(5), x0) == 5 .* ones(length(x0))
             differentiable_kernel_tests(ConstKernel(5.0), ȳ, Ȳ, Ȳ_sq, x0, x1, x2)
             differentiable_kernel_tests(ConstKernel(5.0), ȳ, Ȳ, Ȳ_sq, X0, X1, X2)
         end
 
-        @testset "EQ" begin
+        @timedtestset "EQ" begin
             differentiable_kernel_tests(EQ(), ȳ, Ȳ, Ȳ_sq, x0, x1, x2)
             differentiable_kernel_tests(EQ(), ȳ, Ȳ, Ȳ_sq, X0, X1, X2)
         end
 
-        @testset "PerEQ" begin
+        @timedtestset "PerEQ" begin
             differentiable_kernel_tests(PerEQ(), ȳ, Ȳ, Ȳ_sq, x0, x1, x2; atol=1e-6)
         end
 
-        @testset "Exp" begin
+        @timedtestset "Exp" begin
             differentiable_kernel_tests(Exp(), ȳ, Ȳ, Ȳ_sq, x0 .+ 1, x1, x2)
             differentiable_kernel_tests(Exp(), ȳ, Ȳ, Ȳ_sq, X0, X1, X2)
         end
 
-        @testset "Matern32" begin
+        @timedtestset "Matern32" begin
             differentiable_kernel_tests(Matern32(), ȳ, Ȳ, Ȳ_sq, x0, x1, x2)
             differentiable_kernel_tests(Matern32(), ȳ, Ȳ, Ȳ_sq, X0, X1, X2)
         end
 
-        @testset "Matern52" begin
+        @timedtestset "Matern52" begin
             differentiable_kernel_tests(Matern52(), ȳ, Ȳ, Ȳ_sq, x0, x1, x2)
             differentiable_kernel_tests(Matern52(), ȳ, Ȳ, Ȳ_sq, X0, X1, X2)
         end
 
-        @testset "RQ" begin
-            @testset "α=1.0" begin
+        @timedtestset "RQ" begin
+            @timedtestset "α=1.0" begin
                 differentiable_kernel_tests(RQ(1.0), ȳ, Ȳ, Ȳ_sq, x0, x1, x2)
                 differentiable_kernel_tests(RQ(1.0), ȳ, Ȳ, Ȳ_sq, X0, X1, X2)
             end
-            @testset "α=1.5" begin
+            @timedtestset "α=1.5" begin
                 differentiable_kernel_tests(RQ(1.5), ȳ, Ȳ, Ȳ_sq, x0, x1, x2)
                 differentiable_kernel_tests(RQ(1.5), ȳ, Ȳ, Ȳ_sq, X0, X1, X2)
             end
-            @testset "α=100.0" begin
+            @timedtestset "α=100.0" begin
                 differentiable_kernel_tests(RQ(100.0), ȳ, Ȳ, Ȳ_sq, x0, x1, x2)
                 differentiable_kernel_tests(RQ(100.0), ȳ, Ȳ, Ȳ_sq, X0, X1, X2)
             end
-            @testset "single-input" begin
+            @timedtestset "single-input" begin
                 adjoint_test((α, x, x′)->ew(RQ(α), x, x′), ȳ, 1.5, x0, x1)
                 adjoint_test((α, x, x′)->pw(RQ(α), x, x′), Ȳ, 1.5, x0, x2)
                 adjoint_test((α, x)->ew(RQ(α), x), ȳ, 1.5, x0)
                 adjoint_test((α, x)->pw(RQ(α), x), Ȳ_sq, 1.5, x0)
             end
-            @testset "multi-input" begin
+            @timedtestset "multi-input" begin
                 adjoint_test((α, x, x′)->ew(RQ(α), x, x′), ȳ, 1.5, X0, X1)
                 adjoint_test((α, x, x′)->pw(RQ(α), x, x′), Ȳ, 1.5, X0, X2)
                 adjoint_test((α, x)->ew(RQ(α), x), ȳ, 1.5, X0)
@@ -86,46 +86,46 @@ using LinearAlgebra
             end
         end
 
-        @testset "Linear" begin
+        @timedtestset "Linear" begin
             differentiable_kernel_tests(Linear(), ȳ, Ȳ, Ȳ_sq, x0, x1, x2)
             differentiable_kernel_tests(Linear(), ȳ, Ȳ, Ȳ_sq, X0, X1, X2)
         end
 
-        @testset "Noise" begin
+        @timedtestset "Noise" begin
             @test ew(Noise(), x0, x0) == zeros(length(x0))
             @test pw(Noise(), x0, x0) == zeros(length(x0), length(x0))
             @test ew(Noise(), x0) == ones(length(x0))
             @test pw(Noise(), x0) == Diagonal(ones(length(x0)))
         end
 
-        @testset "Product" begin
+        @timedtestset "Product" begin
             differentiable_kernel_tests(Product(EQ(), Exp()), ȳ, Ȳ, Ȳ_sq, x0, x1, x2)
             differentiable_kernel_tests(Product(EQ(), Exp()), ȳ, Ȳ, Ȳ_sq, X0, X1, X2)
             @test EQ() * Exp() isa Product
         end
 
-        @testset "Stretched" begin
-            @testset "Scalar a" begin
+        @timedtestset "Stretched" begin
+            @timedtestset "Scalar a" begin
                 k = stretch(EQ(), 0.1)
                 differentiable_kernel_tests(k, ȳ, Ȳ, Ȳ_sq, x0, x1, x2; atol=1e-7, rtol=1e-7)
                 differentiable_kernel_tests(k, ȳ, Ȳ, Ȳ_sq, X0, X1, X2; atol=1e-7, rtol=1e-7)
             end
-            @testset "Vector a" begin
+            @timedtestset "Vector a" begin
                 k = stretch(EQ(), randn(rng, D))
                 differentiable_kernel_tests(k, ȳ, Ȳ, Ȳ_sq, X0, X1, X2)
             end
-            @testset "Matrix a" begin
+            @timedtestset "Matrix a" begin
                 k = stretch(EQ(), randn(rng, D, D))
                 differentiable_kernel_tests(k, ȳ, Ȳ, Ȳ_sq, X0, X1, X2)
             end
-            @testset "Convenience Constructors" begin
+            @timedtestset "Convenience Constructors" begin
                 @test eq() isa EQ
                 @test eq(0.5) isa Stretched{Float64, EQ}
             end
         end
     end
 
-    @testset "(is)zero" begin
+    @timedtestset "(is)zero" begin
         @test zero(ZeroKernel()) == ZeroKernel()
         @test zero(EQ()) == ZeroKernel()
         @test iszero(ZeroKernel()) == true

--- a/test/gp/mean.jl
+++ b/test/gp/mean.jl
@@ -1,7 +1,7 @@
 using Stheno: CustomMean, ZeroMean, OneMean, ConstMean
 
-@testset "mean" begin
-    @testset "CustomMean" begin
+@timedtestset "mean" begin
+    @timedtestset "CustomMean" begin
         rng, N, D = MersenneTwister(123456), 11, 2
         x = randn(rng, N)
         foo_mean = x->sum(abs2, x)
@@ -10,7 +10,7 @@ using Stheno: CustomMean, ZeroMean, OneMean, ConstMean
         @test ew(f, x) == map(foo_mean, x)
         differentiable_mean_function_tests(f, randn(rng, N), x)
     end
-    @testset "ZeroMean" begin
+    @timedtestset "ZeroMean" begin
         rng, P, Q, D = MersenneTwister(123456), 3, 2, 4
         X, x = ColsAreObs(randn(rng, D, P)), randn(rng, P)
         f = ZeroMean{Float64}()
@@ -20,7 +20,7 @@ using Stheno: CustomMean, ZeroMean, OneMean, ConstMean
             differentiable_mean_function_tests(f, randn(rng, P), x)
         end
     end
-    @testset "OneMean" begin
+    @timedtestset "OneMean" begin
         rng, P, Q, D = MersenneTwister(123456), 3, 2, 4
         X, x = ColsAreObs(randn(rng, D, P)), randn(rng, P)
         f = OneMean()
@@ -30,7 +30,7 @@ using Stheno: CustomMean, ZeroMean, OneMean, ConstMean
             differentiable_mean_function_tests(f, randn(rng, P), x)
         end
     end
-    @testset "ConstMean" begin
+    @timedtestset "ConstMean" begin
         rng, D, N = MersenneTwister(123456), 5, 3
         X, x, c = ColsAreObs(randn(rng, D, N)), randn(rng, N), randn(rng)
         m = ConstMean(c)
@@ -40,7 +40,7 @@ using Stheno: CustomMean, ZeroMean, OneMean, ConstMean
             differentiable_mean_function_tests(m, randn(rng, N), x)
         end
     end
-    @testset "(is)zero" begin
+    @timedtestset "(is)zero" begin
         @test zero(ZeroMean()) == ZeroMean()
         @test zero(OneMean()) == ZeroMean()
         @test iszero(ZeroMean()) == true

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,15 +1,21 @@
-using Stheno, Test, Random, BlockArrays, StatsFuns
+using Stheno, Test, Random, BlockArrays, StatsFuns, TimerOutputs
 using BlockArrays: _BlockArray
 
 using Stheno: ew, pw, mean_vector, cov, cov_diag
 using Stheno: EQ
+
+const to = TimerOutput()
+
+macro timedtestset(name, code)
+    return esc(:(@timeit to $name @testset $name $code))
+end
 
 include("test_util.jl")
 
 @testset "Stheno" begin
 
     println("util:")
-    @time @testset "util" begin
+    @timedtestset "util" begin
         include(joinpath("util", "zygote_rules.jl"))
         include(joinpath("util", "covariance_matrices.jl"))
         @testset "block_arrays" begin
@@ -21,17 +27,19 @@ include("test_util.jl")
     end
 
     println("abstract_gp:")
-    @time include("abstract_gp.jl")
+    @timedtestset "abstract_gp" begin
+        include("abstract_gp.jl")
+    end
 
     println("gp:")
-    @time @testset "gp" begin
+    @timedtestset "gp" begin
         include(joinpath("gp", "mean.jl"))
         include(joinpath("gp", "kernel.jl"))
         include(joinpath("gp", "gp.jl"))
     end    
 
     println("composite:")
-    @time @testset "composite" begin
+    @timedtestset "composite" begin
         include(joinpath("composite", "test_util.jl"))
         include(joinpath("composite", "indexing.jl"))
         include(joinpath("composite", "cross.jl"))
@@ -42,3 +50,6 @@ include("test_util.jl")
         include(joinpath("composite", "approximate_conditioning.jl"))
     end
 end
+
+display(to)
+

--- a/test/test_util.jl
+++ b/test/test_util.jl
@@ -80,8 +80,8 @@ function adjoint_test(
 
     # Compute forwards-pass and j′vp.
     y, back = Zygote.forward(f, x...)
-    adj_ad = back(ȳ)
-    adj_fd = j′vp(fdm, f, ȳ, x...)
+    @timeit to "adj_ad" adj_ad = back(ȳ)
+    @timeit to "adj_fd" adj_fd = j′vp(fdm, f, ȳ, x...)
 
     # If unary, pull out first thing from ad.
     adj_ad = length(x) == 1 ? first(adj_ad) : adj_ad

--- a/test/util/abstract_data_set.jl
+++ b/test/util/abstract_data_set.jl
@@ -1,69 +1,66 @@
 using Random, LinearAlgebra, Zygote
 using Stheno: ColsAreObs, BlockData
 
-@testset "util/abstract_data_set" begin
+@timedtestset "abstract_data_set" begin
+    rng, N, D = MersenneTwister(123456), 10, 2
+    x, X = randn(rng, N), randn(rng, D, N)
 
-    let
-        rng, N, D = MersenneTwister(123456), 10, 2
-        x, X = randn(rng, N), randn(rng, D, N)
+    # Test Matrix data sets.
+    @timedtestset "ColsAreObs" begin
+        DX = ColsAreObs(X)
+        @test DX == DX
+        @test size(DX) == (N,)
+        @test length(DX) == N
+        @test getindex(DX, 5) isa Vector
+        @test getindex(DX, 5) == X[:, 5]
+        @test getindex(DX, 1:2:6) isa ColsAreObs
+        @test getindex(DX, 1:2:6) == ColsAreObs(X[:, 1:2:6])
+        @test view(DX, 4) isa AbstractVector
+        @test view(DX, 4) == view(X, :, 4)
+        @test view(DX, 1:2:4) isa ColsAreObs
+        @test view(DX, 1:2:4) == ColsAreObs(view(X, :, 1:2:4))
+        @test eltype(DX) == Vector{Float64}
+        @test eachindex(DX) == 1:N
 
-        # Test Matrix data sets.
         let
-            DX = ColsAreObs(X)
-            @test DX == DX
-            @test size(DX) == (N,)
-            @test length(DX) == N
-            @test getindex(DX, 5) isa Vector
-            @test getindex(DX, 5) == X[:, 5]
-            @test getindex(DX, 1:2:6) isa ColsAreObs
-            @test getindex(DX, 1:2:6) == ColsAreObs(X[:, 1:2:6])
-            @test view(DX, 4) isa AbstractVector
-            @test view(DX, 4) == view(X, :, 4)
-            @test view(DX, 1:2:4) isa ColsAreObs
-            @test view(DX, 1:2:4) == ColsAreObs(view(X, :, 1:2:4))
-            @test eltype(DX) == Vector{Float64}
-            @test eachindex(DX) == 1:N
+            @test Zygote.forward(ColsAreObs, X)[1] == DX
+            DX, back = Zygote.forward(ColsAreObs, X)
+            @test back((X=ones(size(X)),))[1] == ones(size(X))
 
-            let
-                @test Zygote.forward(ColsAreObs, X)[1] == DX
-                DX, back = Zygote.forward(ColsAreObs, X)
-                @test back((X=ones(size(X)),))[1] == ones(size(X))
-
-                @test Zygote.forward(DX->DX.X, DX)[1] == X
-                X_, back = Zygote.forward(DX->DX.X, DX)
-                @test back(ones(size(X)))[1].X == ones(size(X))
-            end
+            @test Zygote.forward(DX->DX.X, DX)[1] == X
+            X_, back = Zygote.forward(DX->DX.X, DX)
+            @test back(ones(size(X)))[1].X == ones(size(X))
         end
+    end
 
-        # Test BlockDataSet.
-        let
-            DX = ColsAreObs(X)
-            DxX = BlockData([x, DX])
-            @test size(DxX) == (2N,)
-            @test length(DxX) == 2N
-            @test DxX == DxX
-            @test DxX == BlockData([x, DX])
-            @test length([x for x in DxX]) == 2N
-            @test getindex(DxX, 1) === x[1]
-            @test getindex(DxX, 2) === x[2]
-            @test getindex(DxX, N) === x[N]
-            @test getindex(DxX, N + 1) == DX[1]
-            @test view(DxX, 2, 1) == view(DX, 1)
-            @test view(DxX, 2, N) == view(DX, N)
-            @test eachindex(DxX) isa BlockVector
-            @test eachindex(DxX) == _BlockArray([1:N, N+1:2N], [N, N])
+    # Test BlockDataSet.
+    @timedtestset "BlockData" begin
+        DX = ColsAreObs(X)
+        DxX = BlockData([x, DX])
+        @test size(DxX) == (2N,)
+        @test length(DxX) == 2N
+        @test DxX == DxX
+        @test DxX == BlockData([x, DX])
+        @test length([x for x in DxX]) == 2N
+        @test getindex(DxX, 1) === x[1]
+        @test getindex(DxX, 2) === x[2]
+        @test getindex(DxX, N) === x[N]
+        @test getindex(DxX, N + 1) == DX[1]
+        @test view(DxX, 2, 1) == view(DX, 1)
+        @test view(DxX, 2, N) == view(DX, N)
+        @test eachindex(DxX) isa BlockVector
+        @test eachindex(DxX) == _BlockArray([1:N, N+1:2N], [N, N])
 
-            # Test iteration.
-            @test [x for x in DxX][1] == x[1]
-            @test [x for x in DxX][N] == x[end]
-            @test [x for x in DxX][N + 1] == DX[1]
-            @test [x for x in DxX][end] == DX[end]
+        # Test iteration.
+        @test [x for x in DxX][1] == x[1]
+        @test [x for x in DxX][N] == x[end]
+        @test [x for x in DxX][N + 1] == DX[1]
+        @test [x for x in DxX][end] == DX[end]
 
-            # Test that identically typed arrays yield the appropriate element type.
-            @test eltype(BlockData([randn(5), randn(4)])) == Float64
-            @test eltype(DxX) == Any
-            @test eltype(BlockData([DX, DX])) == Vector{Float64}
-            @test eltype(BlockData([eachindex(DX), eachindex(DX)])) == Int
-        end
+        # Test that identically typed arrays yield the appropriate element type.
+        @test eltype(BlockData([randn(5), randn(4)])) == Float64
+        @test eltype(DxX) == Any
+        @test eltype(BlockData([DX, DX])) == Vector{Float64}
+        @test eltype(BlockData([eachindex(DX), eachindex(DX)])) == Int
     end
 end

--- a/test/util/block_arrays/dense.jl
+++ b/test/util/block_arrays/dense.jl
@@ -1,7 +1,7 @@
 using Random, LinearAlgebra, BlockArrays
 using BlockArrays: cumulsizes, _BlockArray, BlockSizes
 
-@testset "dense" begin
+@timedtestset "dense" begin
 
     # Test construction of a BlockArray via _BlockArray
     @testset "_BlockArray" begin

--- a/test/util/block_arrays/diagonal.jl
+++ b/test/util/block_arrays/diagonal.jl
@@ -101,8 +101,8 @@ function BlockDiagonal_add_tests(rng, blks; grad=true)
     end
 end
 
-@testset "BlockDiagonal" begin
-    @testset "Matrix" begin
+@timedtestset "BlockDiagonal" begin
+    @timedtestset "Matrix" begin
         rng, Ps, Qs = MersenneTwister(123456), [2, 3], [4, 5]
         vs = [randn(rng, Ps[1], Qs[1]), randn(rng, Ps[2], Qs[2])]
         general_BlockDiagonal_tests(rng, vs)
@@ -116,14 +116,14 @@ end
         BlockDiagonal_chol_tests(rng, blks)
         BlockDiagonal_add_tests(rng, blks; grad=false)
     end
-    @testset "Diagonal{T, <:Vector{T}}" begin
+    @timedtestset "Diagonal{T, <:Vector{T}}" begin
         rng, Ps = MersenneTwister(123456), [2, 3]
         vs = [Diagonal(randn(rng, Ps[n])) for n in eachindex(Ps)]
         general_BlockDiagonal_tests(rng, vs)
 
         blocks = [Diagonal(ones(P) + exp.(randn(rng, P))) for P in Ps]
         BlockDiagonal_add_tests(rng, blocks; grad=false)
-        @testset "cholesky" begin
+        @timedtestset "cholesky" begin
             x, ȳ = randn(rng, sum(Ps)), randn(rng, sum(Ps))
             adjoint_test((X, blks)->cholesky(block_diagonal(blks)).U \ X, ȳ, x, blocks)
 
@@ -132,7 +132,7 @@ end
             adjoint_test(blks->logdet(cholesky(block_diagonal(blks))), randn(rng), blocks)
         end
     end
-    @testset "Negation" begin
+    @timedtestset "Negation" begin
         rng, Ps = MersenneTwister(123456), [4, 5, 6, 7]
         A = block_diagonal([randn(rng, P, P) for P in Ps])
 
@@ -147,7 +147,7 @@ end
         @test Matrix(first(back_diag(Ȳ))) == first(back_dens(Matrix(Ȳ)))
         @test first(back_diag(Ȳ)) isa BlockDiagonal
     end
-    @testset "adjoint" begin
+    @timedtestset "adjoint" begin
         rng, Ps = MersenneTwister(123456), [4, 5, 6]
         A = block_diagonal([randn(rng, P, P) for P in Ps])
 
@@ -161,7 +161,7 @@ end
         @test Matrix(first(back(Ȳ))) == first(back_dens(Matrix(Ȳ)))
         @test first(back(Ȳ)) isa BlockDiagonal
     end
-    @testset "transpose" begin
+    @timedtestset "transpose" begin
         rng, Ps = MersenneTwister(123456), [4, 5, 6]
         A = block_diagonal([randn(rng, P, P) for P in Ps])
 
@@ -175,7 +175,7 @@ end
         @test Matrix(first(back(Ȳ))) == first(back_dens(Matrix(Ȳ)))
         @test first(back(Ȳ)) isa BlockDiagonal
     end
-    @testset "UpperTriangular" begin
+    @timedtestset "UpperTriangular" begin
         rng, Ps = MersenneTwister(123456), [4, 5, 6]
         A = block_diagonal([randn(rng, P, P) for P in Ps])
 
@@ -191,7 +191,7 @@ end
         @test Ā_diag == Ā_dens
         @test Ā_diag isa BlockDiagonal
     end
-    @testset "Symmetric" begin
+    @timedtestset "Symmetric" begin
         rng, Ps = MersenneTwister(123456), [4, 5, 6]
         A = block_diagonal([randn(rng, P, P) for P in Ps])
         S = Symmetric(A)
@@ -202,7 +202,7 @@ end
         S_dens, back_dens = Zygote.forward(Symmetric, Matrix(A))
         @test S_diag ≈ S_dens
     end
-    @testset "tr_At_A" begin
+    @timedtestset "tr_At_A" begin
         rng, Ps = MersenneTwister(123456), [4, 5, 6]
         A = block_diagonal([randn(rng, P, P) for P in Ps])
 
@@ -217,7 +217,7 @@ end
         @test Matrix(Ā_diag) ≈ Ā_dens
         @test Ā_diag isa BlockDiagonal
     end
-    @testset "BlockDiagonal * BlockDiagonal" begin
+    @timedtestset "BlockDiagonal * BlockDiagonal" begin
         rng, Ps = MersenneTwister(123456), [4, 5, 6]
         A = block_diagonal([randn(rng, P, P) for P in Ps])
         B = block_diagonal([randn(rng, P, P) for P in Ps])
@@ -240,7 +240,7 @@ end
         @test Ā_diag isa BlockDiagonal
         @test B̄_diag isa BlockDiagonal
     end
-    @testset "BlockDiagonal * Matrix" begin
+    @timedtestset "BlockDiagonal * Matrix" begin
         rng, Ps, Q = MersenneTwister(123456), [4, 5, 6], 11
         A = block_diagonal([randn(rng, P, P) for P in Ps])
         B = randn(rng, sum(Ps), Q)
@@ -258,7 +258,7 @@ end
         @test B̄_diag ≈ B̄_dens
         @test_broken Ā_diag isa BlockDiagonal
     end
-    @testset "BlockDiagonal * Vector" begin
+    @timedtestset "BlockDiagonal * Vector" begin
         rng, Ps = MersenneTwister(123456), [4, 5, 6]
         A = block_diagonal([randn(rng, P, P) for P in Ps])
         x = randn(rng, sum(Ps))
@@ -275,7 +275,7 @@ end
         @test x̄_diag ≈ x̄_dens
         @test_broken Ā_diag isa BlockDiagonal
     end
-    @testset "ldiv(BlockDiagonal, Matrix)" begin
+    @timedtestset "ldiv(BlockDiagonal, Matrix)" begin
         rng, Ps, Q = MersenneTwister(123456), [4, 5, 6], 11
         A = block_diagonal([randn(rng, P, P) for P in Ps])
         B = randn(rng, sum(Ps), Q)
@@ -293,7 +293,7 @@ end
         @test Ā_diag isa BlockDiagonal
         @test blocksizes(Ā_diag) == blocksizes(A)
     end
-    @testset "ldiv(BlockDiagonal, Vector)" begin
+    @timedtestset "ldiv(BlockDiagonal, Vector)" begin
         rng, Ps = MersenneTwister(123456), [4, 5, 6]
         A = block_diagonal([randn(rng, P, P) for P in Ps])
         B = randn(rng, sum(Ps))
@@ -311,7 +311,7 @@ end
         @test Ā_diag isa BlockDiagonal
         @test blocksizes(Ā_diag) == blocksizes(A)
     end
-    @testset "TriangularBlockDiagonal under BlockDiagonal" begin
+    @timedtestset "TriangularBlockDiagonal under BlockDiagonal" begin
         # Stuff isn't triangular anymore, but this should really just work...
         rng, Ps = MersenneTwister(123456), [4, 5]
         U = UpperTriangular(block_diagonal([randn(rng, P, P) for P in Ps]))
@@ -335,7 +335,7 @@ end
         @test Ū_diag isa BlockDiagonal
         @test X̄_diag isa BlockDiagonal
     end
-    @testset "adjoint(TriangularBlockDiagonal) under BlockDiagonal" begin
+    @timedtestset "adjoint(TriangularBlockDiagonal) under BlockDiagonal" begin
         # Legacy test. Should really be doing exactly the same as the block above.
         rng, Ps = MersenneTwister(123456), [4, 5]
         U = UpperTriangular(block_diagonal([randn(rng, P, P) for P in Ps]))

--- a/test/util/covariance_matrices.jl
+++ b/test/util/covariance_matrices.jl
@@ -3,7 +3,7 @@ using Stheno: Xt_A_X, Xt_A_Y, Xt_invA_Y, Xt_invA_X, diag_At_A, diag_At_B, diag_X
     diag_Xt_A_Y, diag_Xt_invA_X, diag_Xt_invA_Y, Xtinv_A_Xinv, tr_At_A
 
 
-@testset "cholesky" begin
+@timedtestset "cholesky" begin
 
     # Test additional operations for Cholesky factorisations.
     let
@@ -65,7 +65,7 @@ using Stheno: Xt_A_X, Xt_A_Y, Xt_invA_Y, Xt_invA_X, diag_At_A, diag_At_B, diag_X
         @test Xtinv_A_Xinv(A, A) isa Symmetric
         @test Xtinv_A_Xinv(A, A) ≈ A \ (A \ A_)'
     end
-    @testset "tr_At_A" begin
+    @timedtestset "tr_At_A" begin
         rng, P = MersenneTwister(123456), 11
         X = randn(rng, P, P)
 

--- a/test/util/fillarrays.jl
+++ b/test/util/fillarrays.jl
@@ -1,40 +1,40 @@
-@testset "fillarrays" begin
-    @testset "Diagonal" begin
+@timedtestset "fillarrays" begin
+    @timedtestset "Diagonal" begin
         rng, N = MersenneTwister(123456), 11
         d, Ȳ = randn(rng, N), randn(rng, N, N)
         adjoint_test(Diagonal, Ȳ, d)
     end
-    @testset "diag" begin
-        @testset "Matrix" begin
+    @timedtestset "diag" begin
+        @timedtestset "Matrix" begin
             rng, N = MersenneTwister(123456), 11
             X, ȳ = randn(rng, N, N), randn(rng, N)
             adjoint_test(diag, ȳ, X)
         end
-        @testset "Symmetric" begin
+        @timedtestset "Symmetric" begin
             rng, N = MersenneTwister(123456), 11
             X, ȳ = randn(rng, N, N), randn(rng, N)
             adjoint_test(diag, ȳ, Symmetric(X))
             adjoint_test(X->diag(Symmetric(X)), ȳ, X)
         end
-        @testset "Diagonal" begin
+        @timedtestset "Diagonal" begin
             rng, N = MersenneTwister(123456), 11
             d, ȳ = randn(rng, N), randn(rng, N)
             D = Diagonal(d)
             adjoint_test(diag, ȳ, D)
             adjoint_test(d->diag(Diagonal(d)), ȳ, D)
         end
-        @testset "Symmetric(Diagonal(...))" begin
+        @timedtestset "Symmetric(Diagonal(...))" begin
             rng, N = MersenneTwister(123456), 11
             d, ȳ = randn(rng, N), randn(rng, N)
             adjoint_test(d->diag(Symmetric(Diagonal(d))), ȳ, d)
         end
-        @testset "Diagonal(::Fill)" begin
+        @timedtestset "Diagonal(::Fill)" begin
             rng, N = MersenneTwister(123456), 11
             x, ȳ = randn(rng), randn(rng, N)
             adjoint_test(x->diag(Diagonal(Fill(x, N))), ȳ, x)
         end
     end
-    @testset "cholesky(Diagonal(Fill(...)))" begin
+    @timedtestset "cholesky(Diagonal(Fill(...)))" begin
         rng, N = MersenneTwister(123456), 4
         d = Fill(1.5, N)
         D = Diagonal(d)
@@ -43,7 +43,7 @@
         @test Zygote.gradient(d->sum(cholesky(Diagonal(d)).U), d)[1] isa Fill
         adjoint_test(x->cholesky(Diagonal(Fill(x, N))).U, randn(rng, N, N), 1.5)
     end
-    @testset "cholesky(Symmetric(Diagonal(Fill(...))))" begin
+    @timedtestset "cholesky(Symmetric(Diagonal(Fill(...))))" begin
         d = Fill(1.5, 4)
         S = Symmetric(Diagonal(d))
         rng, N = MersenneTwister(123456), 11

--- a/test/util/zygote_rules.jl
+++ b/test/util/zygote_rules.jl
@@ -1,14 +1,8 @@
 using FiniteDifferences, Zygote, Distances, Random, LinearAlgebra, StatsFuns
 using Base.Broadcast: broadcast_shape
 
-@testset "zygote_rules" begin
-    @testset "Cholesky (ctor)" begin
-        rng, N = MersenneTwister(123456), 2
-        A, uplo, info = randn(rng, N, N), :U, 0
-        _, back = Zygote.forward(Cholesky, A, uplo, info)
-        @test back((factors=A, uplo=nothing, info=nothing)) == (A, nothing, nothing)
-    end
-    @testset "Cholesky (getproperty)" begin
+@timedtestset "zygote_rules" begin
+    @timedtestset "Cholesky (getproperty)" begin
         rng, N = MersenneTwister(123456), 5
         A = randn(rng, N, N)
         S = A' * A + 1e-6I
@@ -29,146 +23,24 @@ using Base.Broadcast: broadcast_shape
         adjoint_test(A->Cholesky(A, :L, 0).U, randn(rng, N, N), A)
         adjoint_test(A->Cholesky(A, :L, 0).L, randn(rng, N, N), A)
     end
-    @testset "cholesky (Matrix)" begin
-        rng, N = MersenneTwister(123456), 3
-        A = randn(rng, N, N)
-        adjoint_test(A->logdet(cholesky(Symmetric(A' * A + 1e-3I))), randn(rng), A)
-        adjoint_test(A->cholesky(Symmetric(A' * A + 1e-3I)).U, randn(rng, N, N), A)
-        adjoint_test(A->cholesky(Symmetric(A' * A + 1e-3I)).L, randn(rng, N, N), A)
-
-        adjoint_test(A->logdet(cholesky(A' * A + 1e-3I)), randn(rng), A)
-        adjoint_test(A->cholesky(A' * A + 1e-3I).U, randn(rng, N, N), A)
-        adjoint_test(A->cholesky(A' * A + 1e-3I).L, randn(rng, N, N), A)
-    end
-    @testset "colwise(::Euclidean, X, Y; dims=2)" begin
+    @timedtestset "colwise(::Euclidean, X, Y; dims=2)" begin
         rng, D, P = MersenneTwister(123456), 2, 3
         X, Y, D̄ = randn(rng, D, P), randn(rng, D, P), randn(rng, P)
         adjoint_test((X, Y)->colwise(Euclidean(), X, Y), D̄, X, Y)
     end
-    @testset "pairwise(::Euclidean, X, Y; dims=2)" begin
+    @timedtestset "pairwise(::Euclidean, X, Y; dims=2)" begin
         rng, D, P, Q = MersenneTwister(123456), 2, 3, 5
         X, Y, D̄ = randn(rng, D, P), randn(rng, D, Q), randn(rng, P, Q)
         adjoint_test((X, Y)->pairwise(Euclidean(), X, Y; dims=2), D̄, X, Y)
     end
-    @testset "pairwise(::Euclidean, X; dims=2)" begin
+    @timedtestset "pairwise(::Euclidean, X; dims=2)" begin
         rng, D, P = MersenneTwister(123456), 2, 3
         X, D̄ = randn(rng, D, P), randn(rng, P, P)
         adjoint_test(X->pairwise(Euclidean(), X; dims=2), D̄, X)
     end
-    @testset "Diagonal" begin
+    @timedtestset "Diagonal" begin
         rng, N = MersenneTwister(123456), 11
         adjoint_test(Diagonal, rand(rng, N, N), randn(rng, N))
         adjoint_test(x->Diagonal(x).diag, randn(rng, N), randn(rng, N))
-    end
-    @testset "fill" begin
-        rng, N, M, P = MersenneTwister(123456), 11, 6, 5
-        adjoint_test(x->fill(x, N), randn(rng, N), randn(rng))
-        adjoint_test(x->fill(x, N, M), randn(rng, N, M), randn(rng))
-        adjoint_test(x->fill(x, N, M, P), randn(rng, N, M, P), randn(rng))
-    end
-    @testset "xlogx" begin
-        rng = MersenneTwister(123456)
-        # adjoint_test(xlogx, randn(rng), -5.0)
-        # adjoint_test(xlogx, randn(rng), 0.0; fdm=backward_fdm(5, 1))
-        adjoint_test(xlogx, randn(rng), 1.0; fdm=forward_fdm(5, 1))
-        adjoint_test(xlogx, randn(rng), 2.45)
-    end
-    @testset "logistic" begin
-        rng = MersenneTwister(123456)
-        adjoint_test(logistic, randn(rng), -5.0)
-        adjoint_test(logistic, randn(rng), -1.0)
-        adjoint_test(logistic, randn(rng), -eps())
-        adjoint_test(logistic, randn(rng), 0.0)
-        adjoint_test(logistic, randn(rng), eps())
-        adjoint_test(logistic, randn(rng), 1.0)
-        adjoint_test(logistic, randn(rng), 5.0)
-    end
-    @testset "logit" begin
-        rng = MersenneTwister(123456)
-        adjoint_test(logit, randn(rng), 0.1; fdm=forward_fdm(5, 1), atol=1e-7, rtol=1e-7)
-        adjoint_test(logit, randn(rng), 0.3)
-        adjoint_test(logit, randn(rng), 0.5)
-        adjoint_test(logit, randn(rng), 0.7)
-        adjoint_test(logit, randn(rng), 0.9; fdm=backward_fdm(5, 1), atol=1e-7, rtol=1e-7)
-    end
-    @testset "log1psq" begin
-        rng = MersenneTwister(123456)
-        @testset "Float64" begin
-            for x in [-10.0, -5.0, -1.0, -eps(), 0.0, eps(), 1.0, 5.0, 10.0]
-                adjoint_test(log1psq, randn(rng), x)
-            end
-        end
-        @testset "Float32" begin
-            for x in [-10f0, -5f0, -1f0, -eps(Float32), 0f0, eps(Float32), 1f0, 5f0, 10f0]
-                adjoint_test(log1psq, randn(rng, Float32), x;
-                    rtol=10_000 * eps(Float32),
-                    atol=10_000 * eps(Float32),
-                )
-            end
-        end
-    end
-    function test_log1pexp(T, rng, tol, xs)
-        for x in xs
-            adjoint_test(log1pexp, randn(rng, T), x;
-                fdm=FiniteDifferences.Central(5, 1; eps=eps(T), adapt=2),
-                rtol=tol,
-                atol=tol,
-            )
-        end
-    end
-    @testset "log1pexp" begin
-        @testset "Float64" begin
-            @testset "x ∈ (-∞, 18.0)" begin
-                test_log1pexp(Float64, MersenneTwister(123456), 1e5 * eps(),
-                    [-1000.0, -50.0, -25.0, -10.0, 0.0, 10.0, 18.0 - eps()],
-                )
-            end
-            @testset "x ∈ [18.0, 33.3)" begin
-                test_log1pexp(Float64, MersenneTwister(123456), 1e5 * eps(),
-                    [18.0, 18.0 + eps(), 33.3 - eps()],
-                )
-            end
-            @testset "x ∈ [33.3, ∞)" begin
-                test_log1pexp(Float64, MersenneTwister(123456), 1e5 * eps(),
-                    [33.3, 33.3 + eps(), 100.0],
-                )
-            end
-        end
-        @testset "Float32" begin
-            # @testset "x ∈ (-∞, 9f0)" begin
-            #     test_log1pexp(Float32, MersenneTwister(123456), 10_000 * eps(Float32),
-            #         [-1000f0, -50f0, -25f0, -10f0, 0f0, 5f0, 9f0 - eps(Float32)],
-            #     )
-            # end
-            # @testset "x ∈ [9f0, 16f0)" begin
-            #     test_log1pexp(Float32, MersenneTwister(123456), 10_000 * eps(Float32),
-            #         [9f0, 9f0 + eps(Float32), 16f0 - eps(Float32)],
-            #     )
-            # end
-            # @testset "x ∈ [16f0, ∞)" begin
-            #     test_log1pexp(Float32, MersenneTwister(123456), 10_000 * eps(Float32),
-            #         [16f0, 16f0 + eps(Float32), 100f0],
-            #     )
-            # end
-        end
-    end
-    @testset "logsumexp" begin
-        rng = MersenneTwister(123456)
-        @testset "Float64" begin
-            adjoint_test(logsumexp, randn(rng), randn(rng, 1))
-            adjoint_test(logsumexp, randn(rng), randn(rng, 1, 1))
-            adjoint_test(logsumexp, randn(rng), randn(rng, 3))
-            adjoint_test(logsumexp, randn(rng), randn(rng, 3, 4, 5))
-        end
-        @testset "Float32" begin
-            adjoint_test(logsumexp, randn(rng, Float32), randn(rng, Float32, 1);
-                atol=1000 * eps(Float32), rtol=1000 * eps(Float32))
-            adjoint_test(logsumexp, randn(rng, Float32), randn(rng, Float32, 1, 1);
-                atol=1000 * eps(Float32), rtol=1000 * eps(Float32))
-            adjoint_test(logsumexp, randn(rng, Float32), randn(rng, Float32, 2);
-                atol=10_000 * eps(Float32), rtol=10_000 * eps(Float32))
-            adjoint_test(logsumexp, randn(rng, Float32), randn(rng, Float32, 1, 2);
-                atol=10_000 * eps(Float32), rtol=10_000 * eps(Float32))
-        end
     end
 end


### PR DESCRIPTION
Utilise [TimerOutputs.jl](https://github.com/KristofferC/TimerOutputs.jl) to provide some idea of how long we're spending doing what in the test sets. Not intended to provided detailed performance / regression testing, but should at least make it obvious if something is taking _forever_ to run when it really shouldn't be.