### PR TITLE
Towards 1.0

### DIFF
--- a/bench/mean_and_kernel/kernel.jl
+++ b/bench/mean_and_kernel/kernel.jl
@@ -16,11 +16,11 @@
         # )
 
     #     for D in Ds()
-    #         @benchset "ColsAreObs (D=$D) CPU" create_benchmarks(
+    #         @benchset "ColVecs (D=$D) CPU" create_benchmarks(
     #             EQ();
     #             x=randn(D), x′=randn(D),
-    #             x̄s=[ColsAreObs(randn(D, N)) for N in Ns()],
-    #             x̄′s=[ColsAreObs(randn(D, N)) for N in Ns()],
+    #             x̄s=[ColVecs(randn(D, N)) for N in Ns()],
+    #             x̄′s=[ColVecs(randn(D, N)) for N in Ns()],
     #         )
     #     end
 

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -7,6 +7,7 @@ makedocs(
     pages = [
         "Home" => "index.md",
         "Internals" => "internals.md",
+        "Input Types" => "input_types.md",
     ],
 )
 

--- a/docs/src/input_types.md
+++ b/docs/src/input_types.md
@@ -1,0 +1,31 @@
+# Input Types
+
+Stheno enables the user to handle any type of input domain they wish, and provided a common API that must be implemented when considering a new type of domain. Probably the most common domains are the `Real`s and `Vector{<:Real}`, but it is possible to define GPs on strings, graphs, and other non-Euclidean spaces.
+
+Stheno's core assumption is that the user will provide an `AbstractVector{T}` `x`, where `T` is the element type of `x`, whenever indexing. i.e. writing something of the form
+```julia
+f(x)
+f(x, S)
+```
+This is different to many GP frameworks, that allow users to provide e.g. matrices of inputs to represent a vector of vector-inputs. It is explained below why we do _not_ opt for this choice.
+
+
+## Univariate Domains
+
+When constructing a GP whose domain is the real-line, for example when using a GP to solve some kind of time-series problem, it is sufficient to work with `Vector{<:Real}`s of inputs. For example...
+
+
+## Euclidean Space
+
+Many applications of interest involve more than a single input-dimension, such as spatio-temporal modeling or Machine Learning tasks. For these cases we provide `ColVecs <: AbstractVector`.
+```julia
+X_data = randn(5, 100)
+X = ColVecs(X_data)
+```
+tells Stheno that it should treat each column of `X_data` as a vector-valued input. Phrased differently, `X` is an `AbstractVector{T}` where `T <: Vector{<:Real}` whose elements are stored in memory as a dense matrix. This approach has the advantage of making it completely explicit how Stheno will treat a matrix of data, and also simplifies quite a bit of the internal machinery, as all vectors of inputs can actually be assumed to be a subtype of `AbstractVector`.
+
+Future plans include a `RowVecs` type which would instead treat each row of `X_data` as a vector-valued input. If you would like this feature, please raise an issue or a PR to let us know there's demand for it.
+
+
+## Rectilinear Grids of Points in Euclidean Space
+

--- a/docs/src/input_types.md
+++ b/docs/src/input_types.md
@@ -1,21 +1,49 @@
 # Input Types
 
-Stheno enables the user to handle any type of input domain they wish, and provided a common API that must be implemented when considering a new type of domain. Probably the most common domains are the `Real`s and `Vector{<:Real}`, but it is possible to define GPs on strings, graphs, and other non-Euclidean spaces.
+Stheno enables the user to handle any type of input domain they wish, and provides a common API that must be implemented when considering a new way of representing input data so as to ensure that the package knows how to handle them appropriately.
 
-Stheno's core assumption is that the user will provide an `AbstractVector{T}` `x`, where `T` is the element type of `x`, whenever indexing. i.e. writing something of the form
+Discussed below is this interface's core assumptions, a detailed account of a couple of important concrete input types. Additionally, a worked-example of a new input type is provided.
+
+
+
+## The Central Assumption
+
+The central assumption made in all user-facing and internal functions is this: **when a collection of inputs are required, they will subtype `AbstractVector`**. For example, `x isa AbstractVector` when indexing into a GP:
 ```julia
-f(x)
-f(x, S)
+f(x, σ²)
 ```
-This is different to many GP frameworks, that allow users to provide e.g. matrices of inputs to represent a vector of vector-inputs. It is explained below why we do _not_ opt for this choice.
+or computing the covariance matrix assocated with a kernel:
+```julia
+pw(eq(), x)
+```
+When computing the cross-covariance matrix between two GPs
+```julia
+cov(f, g, x_f, x_g)
+```
+`x_f` and `x_g` must be `AbstractVector`s. _All other operations involving collections of inputs has the same restrictions_. Always `AbstractVector`s.
+
+For example, this means that when handling multi-dimensional inputs stored in a `Matrix` they must be wrapped so that the package knows to treat them as a vector. More on this in below in _D-dimensional Euclidean Spaces_.
 
 
-## Univariate Domains
 
-When constructing a GP whose domain is the real-line, for example when using a GP to solve some kind of time-series problem, it is sufficient to work with `Vector{<:Real}`s of inputs. For example...
+## 1-Dimensional Euclidean Space
+
+When constructing a GP whose domain is the real-line, for example when using a GP to solve some kind of time-series problem, it is sufficient to work with `Vector{<:Real}`s of inputs. As such, the following is completely valid:
+```julia
+using Stheno: GPC
+f = GP(eq(), GPC())
+x = randn(10)
+f(x)
+```
+It is also possible to work with other `AbstractArray`s that represent a vector of 1-dimensional points, e.g.
+```julia
+x = range(-5.0, 5.0; length=100)
+f(x)
+```
 
 
-## Euclidean Space
+
+## D-Dimensional Euclidean Space
 
 Many applications of interest involve more than a single input-dimension, such as spatio-temporal modeling or Machine Learning tasks. For these cases we provide `ColVecs <: AbstractVector`.
 ```julia
@@ -24,8 +52,53 @@ X = ColVecs(X_data)
 ```
 tells Stheno that it should treat each column of `X_data` as a vector-valued input. Phrased differently, `X` is an `AbstractVector{T}` where `T <: Vector{<:Real}` whose elements are stored in memory as a dense matrix. This approach has the advantage of making it completely explicit how Stheno will treat a matrix of data, and also simplifies quite a bit of the internal machinery, as all vectors of inputs can actually be assumed to be a subtype of `AbstractVector`.
 
-Future plans include a `RowVecs` type which would instead treat each row of `X_data` as a vector-valued input. If you would like this feature, please raise an issue or a PR to let us know there's demand for it.
+Future plans include a `RowVecs` type which would instead treat each row of `X_data` as a vector-valued input. If you would like this feature, please raise an issue or a PR to let us know there's demand for it. The worked example below actually makes some headway on this, so it provides an excellent starting point for a PR!
 
 
-## Rectilinear Grids of Points in Euclidean Space
 
+### Structure in D-Dimensional Euclidean Space
+
+Consider a rectilinear grid of points in D-dimensional Euclidean space. Such grids of points can be represented in a more memory-efficient manner than can arbitrarily located sets of points. Moreover, this structure can be exploited to dramatically accelerate inference for certain types of problems. Other such examples exist e.g. uniform grids in N-dimensions, and can be exploited to more efficiently represent input data and to accelerate inference.
+
+Work to exploit these kinds of structure is on-going at the time of writing, and will be documented before merging.
+
+
+## Worked Example
+
+As discussed, `ColVecs` is already supported for inputs in D-dimensional Euclidean space, where a collection of inputs is stored in a `Matrix` and each **column** is an input. The following example presents `RowVecs`, which is also made for representing collections inputs residing in D-dimensional Euclidean space but the interpretation is different: each **row** of the matrix corresponds to an input.
+
+Firstly, the new data structure is specified:
+```julia
+struct RowVecs{T<:Real} <: AbstractVector{Vector{T}}
+    X::Matrix{T}
+end
+```
+Observe that it subtypes `AbstractVector`, and each element is a `Vector{T<:Real}`. It has a single field `X`, which is a matrix of elements. It is necessary to implement some parts of the [AbstractArray interface](https://docs.julialang.org/en/v1/manual/interfaces/index.html#man-interface-array-1) to ensure printing and various consistency checks inside the package work as intended:
+```julia
+Base.length(x::RowVecs) = size(x.X, 1)
+Base.size(x::RowVecs) = (length(x),)
+Base.getindex(x::RowVecs, n::Int) = x.X[n, :]
+```
+This structure will now print nicely, and pass some consistency checks, but none of the base `Kernel`s in the package know how to treat it. This means that, for example, new `pw` and `ew` methods that are specialised to `RowVec` must be added:
+```julia
+import Stheno: pw, EQ
+using Distances: SqEuclidean
+pw(k::EQ, x::RowVecs, x′::RowVecs) = exp.(.-pw(SqEuclidean(), x.X, x′.X; dims=1) ./ 2)
+# insert implementations for the unary pw and the two ew methods
+```
+Unfortunately, this really _does_ mean that every `Kernel` needs 4 new methods to handle a new data structure. While the implementation will usually be straightforward, this is somewhat more laborious than is ideal.
+
+There are, however, a couple of tricks that can be employed to avoid this task. If it is the case that a particular data structure can be easily **converted** into e.g. a `ColVecs` object, then one can simply compose the GP of interest with a function doing this conversion:
+```julia
+# It needs to be possible to efficiently broadcast the composition operator
+# over the `RowVecs` data type for the new `to_colvecs` function.
+to_colvecs(x) = error("Shouldn't ever hit this")
+Base.broadcasted(::typeof(to_colvecs), x::RowVecs) = ColVecs(x.X')
+
+using Stheno: GPC
+f = GP(eq(), GPC())
+g = f ∘ to_colvecs # \circ
+
+x = RowVecs(randn(10, 3))
+rand(g(x))
+```

--- a/docs/src/internals.md
+++ b/docs/src/internals.md
@@ -92,7 +92,7 @@ We consider each method in turn.
 - Unary elementwise: compute `k(x[p], x[p])` for `p in eachindex(x)`. Returns a subtype of `AbstractVector{<:Real}` of the same length as `x`.
 - Unary pairwise: compute `k(x[p], x[q])` for `p in eachindex(x)` and `q in eachindex(x)`. Returns a subtype of `AbstractMatrix{<:Real}` whose size is `(length(x), length(x))`. Crucially, output must be positive definite and (approximately) symmetric.
 
-Example implementations can be found [here](https://github.com/willtebbutt/Stheno.jl/blob/master/src/mean_and_kernel/kernel.jl). Often you'll find that multiple versions of each method are implemented, specialised to different input types. For example the `EQ` kernel has (at the time of writing) two implementations of each method, one for inputs `AbstractVector{<:Real}`, and one for `ColsAreObs <: AbstractVector` inputs. These specialisations are for performance purposes.
+Example implementations can be found [here](https://github.com/willtebbutt/Stheno.jl/blob/master/src/mean_and_kernel/kernel.jl). Often you'll find that multiple versions of each method are implemented, specialised to different input types. For example the `EQ` kernel has (at the time of writing) two implementations of each method, one for inputs `AbstractVector{<:Real}`, and one for `ColVecs <: AbstractVector` inputs. These specialisations are for performance purposes.
 
 
 

--- a/src/abstract_gp.jl
+++ b/src/abstract_gp.jl
@@ -77,13 +77,23 @@ rand(rng::AbstractRNG, f::FiniteGP) = vec(rand(rng, f, 1))
 rand(f::FiniteGP) = vec(rand(f, 1))
 
 """
-    logpdf(f::FiniteGP, y::AbstractVector{<:Real})
+    logpdf(f::FiniteGP, Y::AbstractMatrix{<:Real})
 
-The log probability density of `y` under `f`.
+The log probability density of each column of `Y` under `f`.
 """
 function logpdf(f::FiniteGP, y::AbstractVector{<:Real})
     μ, C = mean(f), cholesky(Symmetric(cov(f)))
     return -(length(y) * log(2π) + logdet(C) + Xt_invA_X(C, y - μ)) / 2
+end
+
+"""
+    logpdf(f::FiniteGP, y::AbstractVector{<:Real})
+
+The log probability density of `y` under `f`.
+"""
+function logpdf(f::FiniteGP, Y::AbstractMatrix{<:Real})
+    μ, C = mean(f), cholesky(Symmetric(cov(f)))
+    return -((size(Y, 1) * log(2π) + logdet(C)) .+ diag_Xt_invA_X(C, Y .- μ)) ./ 2
 end
 
 """
@@ -105,7 +115,7 @@ function elbo(f::FiniteGP, y::AV{<:Real}, u::FiniteGP)
 end
 
 function consistency_check(f, y, u)
-    @assert length(f) == length(y)
+    @assert length(f) == size(y, 1)
 end
 Zygote.@nograd consistency_check
 

--- a/src/abstract_gp.jl
+++ b/src/abstract_gp.jl
@@ -163,7 +163,7 @@ Zygote.@nograd _test_block_consistency
 # end
 
 import Base: |, merge
-export ←, |
+export ←, |, Obs
 
 """
     Observation
@@ -176,7 +176,7 @@ struct Observation{Tf<:FiniteGP, Ty<:Vector}
 end
 
 const Obs = Observation
-export Obs
+
 
 ←(f, y) = Observation(f, y)
 get_f(c::Observation) = c.f

--- a/src/composite/compose.jl
+++ b/src/composite/compose.jl
@@ -36,8 +36,8 @@ struct Stretch{T<:Real}
 end
 (s::Stretch)(x) = s.l * x
 broadcasted(s::Stretch{<:Real}, x::StepRangeLen) = s.l .* x
-broadcasted(s::Stretch{<:Real}, x::ColsAreObs) = ColsAreObs(s.l .* x.X)
-broadcasted(s::Stretch{<:AbstractMatrix}, x::ColsAreObs) = ColsAreObs(s.l * x.X)
+broadcasted(s::Stretch{<:Real}, x::ColVecs) = ColVecs(s.l .* x.X)
+broadcasted(s::Stretch{<:AbstractMatrix}, x::ColVecs) = ColVecs(s.l * x.X)
 
 """
     stretch(f::AbstractGP, l::Union{AbstractVecOrMat, Real})
@@ -59,15 +59,15 @@ struct Select{Tidx}
     idx::Tidx
 end
 (f::Select)(x) = x[f.idx]
-broadcasted(f::Select, x::ColsAreObs) = ColsAreObs(x.X[f.idx, :])
-broadcasted(f::Select{<:Integer}, x::ColsAreObs) = x.X[f.idx, :]
+broadcasted(f::Select, x::ColVecs) = ColVecs(x.X[f.idx, :])
+broadcasted(f::Select{<:Integer}, x::ColVecs) = x.X[f.idx, :]
 
 function broadcasted(f::Select, x::AbstractVector{<:CartesianIndex})
     out = Matrix{Int}(undef, length(f.idx), length(x))
     for i in f.idx, n in eachindex(x)
         out[i, n] = x[n][i]
     end
-    return ColsAreObs(out)
+    return ColVecs(out)
 end
 @adjoint function broadcasted(f::Select, x::AV{<:CartesianIndex})
     return broadcasted(f, x), Δ->(nothing, nothing)
@@ -99,7 +99,7 @@ struct Periodic{Tf<:Real}
 end
 (p::Periodic)(t::Real) = [cos((2π * p.f) * t), sin((2π * p.f) * t)]
 function broadcasted(p::Periodic, x::AbstractVector{<:Real})
-    return ColsAreObs(vcat(cos.((2π * p.f) .* x)', sin.((2π * p.f) .* x)'))
+    return ColVecs(vcat(cos.((2π * p.f) .* x)', sin.((2π * p.f) .* x)'))
 end
 
 """

--- a/src/composite/compose.jl
+++ b/src/composite/compose.jl
@@ -119,8 +119,6 @@ struct Shift{Ta<:Union{Real, AV{<:Real}}}
     a::Ta
 end
 (f::Shift{<:Real})(x::Real) = x - f.a
-(f::Shift{<:AV{<:Real}})(x::AV{<:Real}) = x - f.a
-(f::Shift{<:Real})(x::AV{<:Real}) = x .- f.a
 
 broadcasted(f::Shift, x::ColVecs) = ColVecs(x.X .- f.a)
 

--- a/src/composite/conditioning.jl
+++ b/src/composite/conditioning.jl
@@ -63,6 +63,7 @@ function merge(c::Tuple{Vararg{Observation}})
     return merge(map(get_f, c))←block_y
 end
 Observation(c::Tuple{Vararg{Observation}}) = merge(c)
+Observation(c::Observation...) = Observation(c)
 
 # Multi-arg stuff
 |(g::AbstractGP, c::Tuple{Vararg{Observation}}) = g | merge(c)

--- a/src/composite/conditioning.jl
+++ b/src/composite/conditioning.jl
@@ -62,6 +62,7 @@ function merge(c::Tuple{Vararg{Observation}})
     block_y = Vector(BlockVector([map(get_y, c)...]))
     return merge(map(get_f, c))←block_y
 end
+Observation(c::Tuple{Vararg{Observation}}) = merge(c)
 
 # Multi-arg stuff
 |(g::AbstractGP, c::Tuple{Vararg{Observation}}) = g | merge(c)

--- a/src/gp/gp.jl
+++ b/src/gp/gp.jl
@@ -21,6 +21,7 @@ GP(m::Tm, k::Tk, gpc::GPC) where {Tm<:MeanFunction, Tk<:Kernel} = GP{Tm, Tk}(m, 
 GP(f, k::Kernel, gpc::GPC) = GP(CustomMean(f), k, gpc)
 GP(m::Real, k::Kernel, gpc::GPC) = GP(ConstMean(m), k, gpc)
 GP(k::Kernel, gpc::GPC) = GP(ZeroMean(), k, gpc)
+GP(k::Kernel, m, gpc::GPC) = GP(m, k, gpc)
 
 mean_vector(f::GP, x::AV) = ew(f.m, x)
 

--- a/src/gp/kernel.jl
+++ b/src/gp/kernel.jl
@@ -73,14 +73,14 @@ struct EQ <: Kernel end
 # Binary methods.
 ew(::EQ, x::AV{<:Real}, x′::AV{<:Real}) = exp.(.-sqeuclidean.(x, x′) ./ 2)
 pw(::EQ, x::AV{<:Real}, x′::AV{<:Real}) = exp.(.-sqeuclidean.(x, x′') ./ 2)
-ew(::EQ, X::ColsAreObs, X′::ColsAreObs) = exp.(.-colwise(SqEuclidean(), X.X, X′.X) ./ 2)
-pw(::EQ, X::ColsAreObs, X′::ColsAreObs) = exp.(.-pw(SqEuclidean(), X.X, X′.X; dims=2) ./ 2)
+ew(::EQ, X::ColVecs, X′::ColVecs) = exp.(.-colwise(SqEuclidean(), X.X, X′.X) ./ 2)
+pw(::EQ, X::ColVecs, X′::ColVecs) = exp.(.-pw(SqEuclidean(), X.X, X′.X; dims=2) ./ 2)
 
 # Unary methods.
 ew(::EQ, x::AV) = ones(eltype(x), length(x))
 pw(::EQ, x::AV{<:Real}) = pw(EQ(), x, x)
-ew(::EQ, X::ColsAreObs) = ones(eltype(X.X), length(X))
-pw(::EQ, X::ColsAreObs) = exp.(.-pw(SqEuclidean(), X.X; dims=2) ./ 2)
+ew(::EQ, X::ColVecs) = ones(eltype(X.X), length(X))
+pw(::EQ, X::ColVecs) = exp.(.-pw(SqEuclidean(), X.X; dims=2) ./ 2)
 
 # Optimised adjoints. These really do count in terms of performance (I think).
 @adjoint function ew(::EQ, x::AV{<:Real}, x′::AV{<:Real})
@@ -134,14 +134,14 @@ struct Exp <: Kernel end
 # Binary methods
 ew(k::Exp, x::AV{<:Real}, x′::AV{<:Real}) = exp.(.-abs.(x .- x′))
 pw(k::Exp, x::AV{<:Real}, x′::AV{<:Real}) = exp.(.-abs.(x .- x′'))
-ew(k::Exp, x::ColsAreObs, x′::ColsAreObs) = exp.(.-colwise(Euclidean(), x.X, x′.X))
-pw(k::Exp, x::ColsAreObs, x′::ColsAreObs) = exp.(.-pairwise(Euclidean(), x.X, x′.X; dims=2))
+ew(k::Exp, x::ColVecs, x′::ColVecs) = exp.(.-colwise(Euclidean(), x.X, x′.X))
+pw(k::Exp, x::ColVecs, x′::ColVecs) = exp.(.-pairwise(Euclidean(), x.X, x′.X; dims=2))
 
 # Unary methods
 ew(::Exp, x::AV{<:Real}) = ones(eltype(x), length(x))
-ew(::Exp, x::ColsAreObs{T}) where {T} = ones(T, length(x))
+ew(::Exp, x::ColVecs{T}) where {T} = ones(T, length(x))
 pw(k::Exp, x::AV{<:Real}) = pw(k, x, x)
-pw(k::Exp, x::ColsAreObs) = exp.(.-pairwise(Euclidean(), x.X; dims=2))
+pw(k::Exp, x::ColVecs) = exp.(.-pairwise(Euclidean(), x.X; dims=2))
 
 
 
@@ -169,16 +169,16 @@ end
 # Binary methods
 ew(::Matern32, x::AV{<:Real}, x′::AV{<:Real}) = _matern32.(abs.(x .- x′))
 pw(::Matern32, x::AV{<:Real}, x′::AV{<:Real}) = _matern32.(abs.(x .- x′'))
-ew(k::Matern32, x::ColsAreObs, x′::ColsAreObs) = _matern32.(colwise(Euclidean(), x.X, x′.X))
-function pw(k::Matern32, x::ColsAreObs, x′::ColsAreObs)
+ew(k::Matern32, x::ColVecs, x′::ColVecs) = _matern32.(colwise(Euclidean(), x.X, x′.X))
+function pw(k::Matern32, x::ColVecs, x′::ColVecs)
     return _matern32.(pairwise(Euclidean(), x.X, x′.X; dims=2))
 end
 
 # Unary methods
 ew(::Matern32, x::AV{<:Real}) = ones(eltype(x), length(x))
 pw(k::Matern32, x::AV{<:Real}) = pw(k, x, x)
-ew(::Matern32, x::ColsAreObs{T}) where {T<:Real} = ones(T, length(x))
-pw(::Matern32, x::ColsAreObs) = _matern32.(pairwise(Euclidean(), x.X; dims=2))
+ew(::Matern32, x::ColVecs{T}) where {T<:Real} = ones(T, length(x))
+pw(::Matern32, x::ColVecs) = _matern32.(pairwise(Euclidean(), x.X; dims=2))
 
 
 
@@ -197,16 +197,16 @@ end
 # Binary methods
 ew(::Matern52, x::AV{<:Real}, x′::AV{<:Real}) = _matern52.(abs.(x .- x′))
 pw(::Matern52, x::AV{<:Real}, x′::AV{<:Real}) = _matern52.(abs.(x .- x′'))
-ew(k::Matern52, x::ColsAreObs, x′::ColsAreObs) = _matern52.(colwise(Euclidean(), x.X, x′.X))
-function pw(k::Matern52, x::ColsAreObs, x′::ColsAreObs)
+ew(k::Matern52, x::ColVecs, x′::ColVecs) = _matern52.(colwise(Euclidean(), x.X, x′.X))
+function pw(k::Matern52, x::ColVecs, x′::ColVecs)
     return _matern52.(pairwise(Euclidean(), x.X, x′.X; dims=2))
 end
 
 # Unary methods
 ew(::Matern52, x::AV{<:Real}) = ones(eltype(x), length(x))
 pw(k::Matern52, x::AV{<:Real}) = pw(k, x, x)
-ew(::Matern52, x::ColsAreObs{T}) where {T<:Real} = ones(T, length(x))
-pw(::Matern52, x::ColsAreObs) = _matern52.(pairwise(Euclidean(), x.X; dims=2))
+ew(::Matern52, x::ColVecs{T}) where {T<:Real} = ones(T, length(x))
+pw(::Matern52, x::ColVecs) = _matern52.(pairwise(Euclidean(), x.X; dims=2))
 
 
 
@@ -224,18 +224,18 @@ _rq(d, α) = (1 + d / (2α))^(-α)
 # Binary methods
 ew(k::RQ, x::AV{<:Real}, x′::AV{<:Real}) = _rq.(sqeuclidean.(x, x′), k.α)
 pw(k::RQ, x::AV{<:Real}, x′::AV{<:Real}) = _rq.(sqeuclidean.(x, x′'), k.α)
-function ew(k::RQ, x::ColsAreObs, x′::ColsAreObs)
+function ew(k::RQ, x::ColVecs, x′::ColVecs)
     return _rq.(colwise(SqEuclidean(), x.X, x′.X), k.α)
 end
-function pw(k::RQ, x::ColsAreObs, x′::ColsAreObs)
+function pw(k::RQ, x::ColVecs, x′::ColVecs)
     return _rq.(pairwise(SqEuclidean(), x.X, x′.X; dims=2), k.α)
 end
 
 # Unary methods
 ew(k::RQ, x::AV{<:Real}) = ones(eltype(x), length(x))
 pw(k::RQ, x::AV{<:Real}) = pw(k, x, x)
-ew(k::RQ, x::ColsAreObs{T}) where {T<:Real} = ones(T, length(x))
-pw(k::RQ, x::ColsAreObs) = _rq.(pairwise(SqEuclidean(), x.X; dims=2), k.α)
+ew(k::RQ, x::ColVecs{T}) where {T<:Real} = ones(T, length(x))
+pw(k::RQ, x::ColVecs) = _rq.(pairwise(SqEuclidean(), x.X; dims=2), k.α)
 
 
 
@@ -249,14 +249,14 @@ struct Linear <: Kernel end
 # Binary methods
 ew(k::Linear, x::AV{<:Real}, x′::AV{<:Real}) = x .* x′
 pw(k::Linear, x::AV{<:Real}, x′::AV{<:Real}) = x .* x′'
-ew(k::Linear, x::ColsAreObs, x′::ColsAreObs) = reshape(sum(x.X .* x′.X; dims=1), :)
-pw(k::Linear, x::ColsAreObs, x′::ColsAreObs) = x.X' * x′.X
+ew(k::Linear, x::ColVecs, x′::ColVecs) = reshape(sum(x.X .* x′.X; dims=1), :)
+pw(k::Linear, x::ColVecs, x′::ColVecs) = x.X' * x′.X
 
 # Unary methods
 ew(k::Linear, x::AV{<:Real}) = x.^2
 pw(k::Linear, x::AV{<:Real}) = x .* x'
-ew(k::Linear, x::ColsAreObs) = reshape(sum(abs2.(x.X); dims=1), :)
-pw(k::Linear, x::ColsAreObs) = x.X' * x.X
+ew(k::Linear, x::ColVecs) = reshape(sum(abs2.(x.X); dims=1), :)
+pw(k::Linear, x::ColVecs) = x.X' * x.X
 
 
 
@@ -366,28 +366,28 @@ ew(k::Stretched{<:Real}, x::AV{<:Real}) = ew(k.k, k.a .* x)
 pw(k::Stretched{<:Real}, x::AV{<:Real}) = pw(k.k, k.a .* x)
 
 # Binary methods (scalar and vector `a`, vector-valued input)
-function ew(k::Stretched{<:Union{Real, AV{<:Real}}}, x::ColsAreObs, x′::ColsAreObs)
-    return ew(k.k, ColsAreObs(k.a .* x.X), ColsAreObs(k.a .* x′.X))
+function ew(k::Stretched{<:Union{Real, AV{<:Real}}}, x::ColVecs, x′::ColVecs)
+    return ew(k.k, ColVecs(k.a .* x.X), ColVecs(k.a .* x′.X))
 end
-function pw(k::Stretched{<:Union{Real, AV{<:Real}}}, x::ColsAreObs, x′::ColsAreObs)
-    return pw(k.k, ColsAreObs(k.a .* x.X), ColsAreObs(k.a .* x′.X))
+function pw(k::Stretched{<:Union{Real, AV{<:Real}}}, x::ColVecs, x′::ColVecs)
+    return pw(k.k, ColVecs(k.a .* x.X), ColVecs(k.a .* x′.X))
 end
 
 # Unary methods (scalar and vector `a`, vector-valued input)
-ew(k::Stretched{<:Union{Real, AV{<:Real}}}, x::ColsAreObs) = ew(k.k, ColsAreObs(k.a .* x.X))
-pw(k::Stretched{<:Union{Real, AV{<:Real}}}, x::ColsAreObs) = pw(k.k, ColsAreObs(k.a .* x.X))
+ew(k::Stretched{<:Union{Real, AV{<:Real}}}, x::ColVecs) = ew(k.k, ColVecs(k.a .* x.X))
+pw(k::Stretched{<:Union{Real, AV{<:Real}}}, x::ColVecs) = pw(k.k, ColVecs(k.a .* x.X))
 
 # Binary methods (matrix `a`, vector-valued input)
-function ew(k::Stretched{<:AM{<:Real}}, x::ColsAreObs, x′::ColsAreObs)
-    return ew(k.k, ColsAreObs(k.a * x.X), ColsAreObs(k.a * x′.X))
+function ew(k::Stretched{<:AM{<:Real}}, x::ColVecs, x′::ColVecs)
+    return ew(k.k, ColVecs(k.a * x.X), ColVecs(k.a * x′.X))
 end
-function pw(k::Stretched{<:AM{<:Real}}, x::ColsAreObs, x′::ColsAreObs)
-    return pw(k.k, ColsAreObs(k.a * x.X), ColsAreObs(k.a * x′.X))
+function pw(k::Stretched{<:AM{<:Real}}, x::ColVecs, x′::ColVecs)
+    return pw(k.k, ColVecs(k.a * x.X), ColVecs(k.a * x′.X))
 end
 
 # Unary methods (scalar and vector `a`, vector-valued input)
-ew(k::Stretched{<:AM{<:Real}}, x::ColsAreObs) = ew(k.k, ColsAreObs(k.a * x.X))
-pw(k::Stretched{<:AM{<:Real}}, x::ColsAreObs) = pw(k.k, ColsAreObs(k.a * x.X))
+ew(k::Stretched{<:AM{<:Real}}, x::ColVecs) = ew(k.k, ColVecs(k.a * x.X))
+pw(k::Stretched{<:AM{<:Real}}, x::ColVecs) = pw(k.k, ColVecs(k.a * x.X))
 
 # Create convenience versions of each of the kernels that accept a length scale.
 for (k, K) in (

--- a/src/gp/kernel.jl
+++ b/src/gp/kernel.jl
@@ -401,6 +401,7 @@ end
 
 rq(α) = RQ(α)
 rq(α, l) = stretch(rq(α), l)
+export rq
 
 # """
 #     Poly{Tσ<:Real} <: Kernel

--- a/src/util/abstract_data_set.jl
+++ b/src/util/abstract_data_set.jl
@@ -1,36 +1,36 @@
 import Base: size, eachindex, getindex, view, ==, eltype, convert, zero, getproperty
 import Distances: pairwise
 import Zygote: literal_getproperty, accum
-export ColsAreObs
+export ColVecs
 
 """
-    ColsAreObs{T, TX<:AbstractMatrix}
+    ColVecs{T, TX<:AbstractMatrix}
 
 A lightweight box for an `AbstractMatrix` to make it behave like a vector of vectors.
 """
-struct ColsAreObs{T, TX<:AbstractMatrix{T}} <: AbstractVector{Vector{T}}
+struct ColVecs{T, TX<:AbstractMatrix{T}} <: AbstractVector{Vector{T}}
     X::TX
-    ColsAreObs(X::TX) where {T, TX<:AbstractMatrix{T}} = new{T, TX}(X)
+    ColVecs(X::TX) where {T, TX<:AbstractMatrix{T}} = new{T, TX}(X)
 end
 
-@adjoint function ColsAreObs(X::AbstractMatrix)
+@adjoint function ColVecs(X::AbstractMatrix)
     back(Δ::NamedTuple) = (Δ.X,)
     back(Δ::AbstractMatrix) = (Δ,)
     function back(Δ::AbstractVector{<:AbstractVector{<:Real}})
         throw(error("In slow method"))
     end
-    return ColsAreObs(X), back
+    return ColVecs(X), back
 end
 
-==(D1::ColsAreObs, D2::ColsAreObs) = D1.X == D2.X
-size(D::ColsAreObs) = (size(D.X, 2),)
-getindex(D::ColsAreObs, n::Int) = D.X[:, n]
-getindex(D::ColsAreObs, n::CartesianIndex{1}) = getindex(D, n[1])
-getindex(D::ColsAreObs, n) = ColsAreObs(D.X[:, n])
-view(D::ColsAreObs, n::Int) = view(D.X, :, n)
-view(D::ColsAreObs, n) = ColsAreObs(view(D.X, :, n))
-eltype(D::ColsAreObs{T}) where T = Vector{T}
-zero(D::ColsAreObs) = ColsAreObs(zero(D.X))
+==(D1::ColVecs, D2::ColVecs) = D1.X == D2.X
+size(D::ColVecs) = (size(D.X, 2),)
+getindex(D::ColVecs, n::Int) = D.X[:, n]
+getindex(D::ColVecs, n::CartesianIndex{1}) = getindex(D, n[1])
+getindex(D::ColVecs, n) = ColVecs(D.X[:, n])
+view(D::ColVecs, n::Int) = view(D.X, :, n)
+view(D::ColVecs, n) = ColVecs(view(D.X, :, n))
+eltype(D::ColVecs{T}) where T = Vector{T}
+zero(D::ColVecs) = ColVecs(zero(D.X))
 
 
 

--- a/test/abstract_gp.jl
+++ b/test/abstract_gp.jl
@@ -29,7 +29,7 @@ end
     end
     @testset "rand (deterministic)" begin
         rng, N, D = MersenneTwister(123456), 10, 2
-        X, x, Σy = ColsAreObs(randn(rng, D, N)), randn(rng, N), zeros(N, N)
+        X, x, Σy = ColVecs(randn(rng, D, N)), randn(rng, N), zeros(N, N)
         Σy = generate_noise_matrix(rng, N)
         fX = FiniteGP(GP(1, EQ(), GPC()), X, Σy)
         fx = FiniteGP(GP(1, EQ(), GPC()), x, Σy)
@@ -43,7 +43,7 @@ end
     end
     @testset "rand (statistical)" begin
         rng, N, D, μ0, S = MersenneTwister(123456), 10, 2, 1, 100_000
-        X, Σy = ColsAreObs(randn(rng, D, N)), 1e-12
+        X, Σy = ColVecs(randn(rng, D, N)), 1e-12
         f = FiniteGP(GP(1, EQ(), GPC()), X, Σy)
 
         # Check mean + covariance estimates approximately converge for single-GP sampling.

--- a/test/abstract_gp.jl
+++ b/test/abstract_gp.jl
@@ -122,7 +122,7 @@ end
     #     # end
     # end
     @testset "logpdf / elbo" begin
-        rng, N, σ, gpc = MersenneTwister(123456), 10, 1e-1, GPC()
+        rng, N, S, σ, gpc = MersenneTwister(123456), 10, 11, 1e-1, GPC()
         x = collect(range(-3.0, stop=3.0, length=N))
         f = GP(1, EQ(), gpc)
         fx, y = FiniteGP(f, x, 0), FiniteGP(f, x, σ^2)
@@ -132,10 +132,16 @@ end
         @test logpdf(y, ŷ) isa Real
         @test logpdf(y, ŷ) ≈ logpdf(MvNormal(Vector(mean(y)), cov(y)), ŷ)
 
+        # Check that multi-sample logpdf returns the correct type and is consistent with
+        # single-sample logpdf
+        Ŷ = rand(rng, y, S)
+        @test logpdf(y, Ŷ) isa Vector{Float64}
+        @test logpdf(y, Ŷ) ≈ [logpdf(y, Ŷ[:, n]) for n in 1:S]
+
         # Check gradient of logpdf at mean is zero for `f`.
         adjoint_test(ŷ->logpdf(fx, ŷ), 1, ones(size(ŷ)))
         lp, back = Zygote.forward(ŷ->logpdf(fx, ŷ), ones(size(ŷ)))
-        @test back(randn(rng))[1] == zeros(size(ŷ)) 
+        @test back(randn(rng))[1] == zeros(size(ŷ))
 
         # Check that gradient of logpdf at mean is zero for `y`.
         adjoint_test(ŷ->logpdf(y, ŷ), 1, ones(size(ŷ)))
@@ -149,13 +155,24 @@ end
             l̄, collect(x);
             atol=1e-8, rtol=1e-8,
         )
+        adjoint_test(
+            x->sum(logpdf(FiniteGP(f, x, 1e-3), ones(size(Ŷ)))),
+            l̄, collect(x);
+            atol=1e-8, rtol=1e-8,
+        )
 
         # Check that the gradient w.r.t. the noise is approximately correct for `f`.
-        adjoint_test(σ_->logpdf(FiniteGP(f, x, softplus(σ_)), ŷ), l̄, randn(rng))
+        σ_ = randn(rng)
+        adjoint_test((σ_, ŷ)->logpdf(FiniteGP(f, x, softplus(σ_)), ŷ), l̄, σ_, ŷ)
+        adjoint_test((σ_, Ŷ)->sum(logpdf(FiniteGP(f, x, softplus(σ_)), Ŷ)), l̄, σ_, Ŷ)
 
         # Check that the gradient w.r.t. a scaling of the GP works.
         adjoint_test(
             α->logpdf(FiniteGP(α * f, x, 1e-1), ŷ), l̄, randn(rng);
+            atol=1e-8, rtol=1e-8,
+        )
+        adjoint_test(
+            α->sum(logpdf(FiniteGP(α * f, x, 1e-1), Ŷ)), l̄, randn(rng);
             atol=1e-8, rtol=1e-8,
         )
 

--- a/test/composite/addition.jl
+++ b/test/composite/addition.jl
@@ -3,7 +3,7 @@ using Stheno: GPC, EQ, Exp
 @timedtestset "addition" begin
     @timedtestset "Correlated GPs" begin
         rng, N, N′, D, gpc = MersenneTwister(123456), 5, 6, 2, GPC()
-        X, X′ = ColsAreObs(randn(rng, D, N)), ColsAreObs(randn(rng, D, N′))
+        X, X′ = ColVecs(randn(rng, D, N)), ColVecs(randn(rng, D, N′))
         f1, f2 = GP(1, EQ(), gpc), GP(2, Exp(), gpc)
         f3 = f1 + f2
         f4 = f1 + f3
@@ -32,7 +32,7 @@ using Stheno: GPC, EQ, Exp
     end
     @timedtestset "Verify mean / kernel numerically" begin
         rng, N, D = MersenneTwister(123456), 5, 6
-        X = ColsAreObs(randn(rng, D, N))
+        X = ColVecs(randn(rng, D, N))
         c, f = randn(rng), GP(5, EQ(), GPC())
 
         @test mean((f + c)(X)) == mean(f(X)) .+ c

--- a/test/composite/compose.jl
+++ b/test/composite/compose.jl
@@ -1,43 +1,138 @@
 using Stheno: GPC, EQ, Exp
 
 @timedtestset "compose" begin
-    rng, N, N′, gpc = MersenneTwister(123456), 5, 3, GPC()
-    x, x′ = randn(rng, N), randn(rng, N′)
-    f, g, h = GP(sin, EQ(), gpc), cos, GP(exp, Exp(), gpc)
-    fg = f ∘ g
+    @timedtestset "general" begin
+        rng, N, N′, gpc = MersenneTwister(123456), 5, 3, GPC()
+        x, x′ = randn(rng, N), randn(rng, N′)
+        f, g, h = GP(sin, EQ(), gpc), cos, GP(exp, Exp(), gpc)
+        fg = f ∘ g
 
-    # Check marginals statistics inductively.
-    @test mean(fg(x)) == mean(f(map(g, x)))
-    @test cov(fg(x)) == cov(f(map(g, x)))
-    
-    # Check cross covariance between transformed process and original inductively.
-    @test cov(fg(x), fg(x′)) == cov(f(map(g, x)), f(map(g, x′)))
-    @test cov(fg(x), f(x′)) == cov(f(map(g, x)), f(x′))
-    @test cov(f(x), fg(x′)) == cov(f(x), f(map(g, x′)))
+        # Check marginals statistics inductively.
+        @test mean(fg(x)) == mean(f(map(g, x)))
+        @test cov(fg(x)) == cov(f(map(g, x)))
+        
+        # Check cross covariance between transformed process and original inductively.
+        @test cov(fg(x), fg(x′)) == cov(f(map(g, x)), f(map(g, x′)))
+        @test cov(fg(x), f(x′)) == cov(f(map(g, x)), f(x′))
+        @test cov(f(x), fg(x′)) == cov(f(x), f(map(g, x′)))
 
-    # Check cross covariance between transformed process and independent absolutely.
-    @test cov(fg(x), h(x′)) == zeros(length(x), length(x′))
-    @test cov(h(x), fg(x′)) == zeros(length(x), length(x′))
+        # Check cross covariance between transformed process and independent absolutely.
+        @test cov(fg(x), h(x′)) == zeros(length(x), length(x′))
+        @test cov(h(x), fg(x′)) == zeros(length(x), length(x′))
 
-    @timedtestset "Consistency Tests" begin
-        P, Q = 4, 3
-        x0, x1, x2, x3 = randn(rng, P), randn(rng, Q), randn(rng, Q), randn(rng, P)
-        abstractgp_interface_tests(fg, f, x0, x1, x2, x3)
-        abstractgp_interface_tests(stretch(f, 0.1), f, x0, x1, x2, x3)
+        @timedtestset "Consistency Tests" begin
+            P, Q = 4, 3
+            x0, x1, x2, x3 = randn(rng, P), randn(rng, Q), randn(rng, Q), randn(rng, P)
+            abstractgp_interface_tests(fg, f, x0, x1, x2, x3)
+            abstractgp_interface_tests(stretch(f, 0.1), f, x0, x1, x2, x3)
 
-        # f = GP(EQ(), GPC())
-        # abstractgp_interface_tests(periodic(f, 0.1), f, x0, x1, x2, x3)
+            # f = GP(EQ(), GPC())
+            # abstractgp_interface_tests(periodic(f, 0.1), f, x0, x1, x2, x3)
+        end
+        @timedtestset "Diff Tests" begin
+            standard_1D_tests(
+                MersenneTwister(123456),
+                Dict(:σ=>0.5),
+                θ->begin
+                    f = θ[:σ] * GP(sin, EQ(), GPC())
+                    return stretch(f, 0.5), f
+                end,
+                collect(range(-2.0, 2.0; length=N)),
+                collect(range(-1.5, 2.2; length=N′)),
+            )
+        end
     end
-    @timedtestset "Diff Tests" begin
-        standard_1D_tests(
-            MersenneTwister(123456),
-            Dict(:σ=>0.5),
-            θ->begin
-                f = θ[:σ] * GP(sin, EQ(), GPC())
-                return stretch(f, 0.5), f
-            end,
-            collect(range(-2.0, 2.0; length=N)),
-            collect(range(-1.5, 2.2; length=N′)),
-        )
+    @timedtestset "Stretch" begin
+        @timedtestset "scalar stretch" begin
+            rng, N, λ = MersenneTwister(123456), 3, 0.51
+            x = randn(rng)
+            f = GP(1.3, EQ(), GPC())
+            g = stretch(f, λ)
+
+            @timedtestset "scalar input" begin
+                @test first(cov(f, g, [0.0], [0.0])) == 1.0
+                @test first(cov(f, g, [λ * x], [x])) == 1.0
+                standard_1D_tests(
+                    MersenneTwister(123456),
+                    Dict(:σ=>0.5, :l=>0.32),
+                    θ->begin
+                        f_ = θ[:σ] * GP(sin, EQ(), GPC())
+                        return stretch(f_, θ[:l]), f_
+                    end,
+                    collect(range(-2.0, 2.0; length=N)),
+                    collect(range(-1.5, 2.2; length=5)),
+                )
+            end
+            @timedtestset "vector input" begin
+                D = 11
+                X = randn(rng, D, 1)
+                @test first(cov(f, g, ColVecs(zeros(D, 1)), ColVecs(zeros(D, 1)))) == 1.0
+                @test first(cov(f, g, ColVecs(λ .* X), ColVecs(X))) == 1.0
+            end
+        end
+        @timedtestset "Vector stretch" begin
+            rng, N, D = MersenneTwister(123456), 3, 7
+            λ = randn(rng, D)
+            f = GP(1.0, EQ(), GPC())
+            g = stretch(f, λ)
+
+            X = randn(rng, D, 1)
+            @test first(cov(f, g, ColVecs(zeros(D, 1)), ColVecs(zeros(D, 1)))) == 1.0
+            @test first(cov(f, g, ColVecs(Diagonal(λ) * X), ColVecs(X))) == 1.0
+        end
+        @timedtestset "Matrix stretch" begin
+            rng, N, D = MersenneTwister(123456), 3, 7
+            A = randn(rng, D, D)
+            f = GP(1.0, EQ(), GPC())
+            g = stretch(f, A)
+
+            X = randn(rng, D, 1)
+            @test first(cov(f, g, ColVecs(zeros(D, 1)), ColVecs(zeros(D, 1)))) == 1.0
+            @test first(cov(f, g, ColVecs(A * X), ColVecs(X))) == 1.0
+        end
+    end
+    @timedtestset "Select" begin
+        rng, N, D = MersenneTwister(123456), 3, 6
+        idx = [1, 3]
+        f = GP(1.3, EQ(), GPC())
+        g = select(f, idx)
+
+        X = randn(rng, D, N)
+        X_f = ColVecs(X[idx, :])
+        X_g = ColVecs(X)
+        @test cov(f, g, X_f, X_g) ≈ cov(f, X_f, X_f)
+        @test cov(f, g, X_f, X_g) ≈ cov(g, X_g, X_g)
+    end
+    @timedtestset "Shift" begin
+        @timedtestset "Shift{Float64}" begin
+            rng, N, D = MersenneTwister(123456), 3, 6
+            a = randn(rng)
+            f = GP(1.3, EQ(), GPC())
+            g = shift(f, a)
+
+            x = randn(rng, N)
+            x_f = x .- a
+            x_g = x
+            @test cov(f, g, x_f, x_g) ≈ cov(f, x_f, x_f)
+            @test cov(f, g, x_f, x_g) ≈ cov(g, x_g, x_g)
+
+            X = randn(rng, D, N)
+            X_f = ColVecs(X .- a)
+            X_g = ColVecs(X)
+            @test cov(f, g, X_f, X_g) ≈ cov(f, X_f, X_f)
+            @test cov(f, g, X_f, X_g) ≈ cov(g, X_g, X_g)
+        end
+        @timedtestset "Shift{Vector{Float64}}" begin
+            rng, N, D = MersenneTwister(123456), 3, 6
+            a = randn(rng, D)
+            f = GP(1.3, EQ(), GPC())
+            g = shift(f, a)
+
+            X = randn(rng, D, N)
+            X_f = ColVecs(X .- a)
+            X_g = ColVecs(X)
+            @test cov(f, g, X_f, X_g) ≈ cov(f, X_f, X_f)
+            @test cov(f, g, X_f, X_g) ≈ cov(g, X_g, X_g)
+        end
     end
 end

--- a/test/composite/product.jl
+++ b/test/composite/product.jl
@@ -8,7 +8,7 @@ using Stheno: GPC, EQ
     end
     @timedtestset "multiply by constant" begin
         rng, N, N′, D = MersenneTwister(123456), 3, 5, 2
-        X, X′ = ColsAreObs(randn(rng, D, N)), ColsAreObs(randn(rng, D, N′))
+        X, X′ = ColVecs(randn(rng, D, N)), ColVecs(randn(rng, D, N′))
         g1, c, c′ = GP(1, EQ(), GPC()), -4.3, 2.1
         g2, g2′ = c * g1, g1 * c′
         g3, g3′ = c * g2, g2′ * c′
@@ -69,7 +69,7 @@ using Stheno: GPC, EQ
     end
     @timedtestset "multiply by function" begin
         rng, N, N′, D = MersenneTwister(123456), 3, 5, 2
-        X, X′ = ColsAreObs(randn(rng, D, N)), ColsAreObs(randn(rng, D, N′))
+        X, X′ = ColVecs(randn(rng, D, N)), ColVecs(randn(rng, D, N′))
         g1, f, f′ = GP(1, EQ(), GPC()), x->sum(sin, x), x->sum(cos, x)
         g2, g2′ = f * g1, g1 * f′
         g3, g3′ = f * g2, g2′ * f′

--- a/test/gp/gp.jl
+++ b/test/gp/gp.jl
@@ -21,9 +21,16 @@ using Stheno: EQ, Exp
 
     # Check that mean-function specialisations work as expected.
     @timedtestset "sugar" begin
-        m = 5.1
         @test GP(5, EQ(), GPC()).m isa ConstMean
         @test GP(EQ(), GPC()).m isa ZeroMean
+    end
+
+    # Check that GP(kernel, mean, gpc) always works.
+    @timedtestset "reversed construction" begin
+        @test GP(eq(), CustomMean(sin), GPC()).m isa CustomMean{typeof(sin)}
+        @test GP(eq(), CustomMean(sin), GPC()).k isa Stheno.EQ
+        @test GP(eq(), 5.0, GPC()).m isa ConstMean
+        @test GP(eq(), 5.0, GPC()).k isa Stheno.EQ
     end
 
     # Test the creation of indepenent GPs.

--- a/test/gp/kernel.jl
+++ b/test/gp/kernel.jl
@@ -13,9 +13,9 @@ using LinearAlgebra
         x2_r, x3_r = range(-5.0, step=2, length=N), range(-3.0, step=1, length=N′)
         x4_r = range(-2.0, step=2, length=N′)
 
-        X0 = ColsAreObs(randn(rng, D, N))
-        X1 = ColsAreObs(randn(rng, D, N))
-        X2 = ColsAreObs(randn(rng, D, N′))
+        X0 = ColVecs(randn(rng, D, N))
+        X1 = ColVecs(randn(rng, D, N))
+        X2 = ColVecs(randn(rng, D, N′))
 
         ȳ, Ȳ, Ȳ_sq = randn(rng, N), randn(rng, N, N′), randn(rng, N, N)
 

--- a/test/gp/kernel.jl
+++ b/test/gp/kernel.jl
@@ -133,8 +133,22 @@ using LinearAlgebra
                 differentiable_kernel_tests(k, ȳ, Ȳ, Ȳ_sq, X0, X1, X2)
             end
             @timedtestset "Convenience Constructors" begin
-                @test eq() isa EQ
-                @test eq(0.5) isa Stretched{Float64, EQ}
+                unstretched = [
+                    (eq(), EQ()),
+                    (rq(1.5), RQ(1.5)),
+                ]
+                stretched = [
+                    (eq(0.7), stretch(EQ(), 0.7)),
+                    (rq(1.5, 0.5), stretch(RQ(1.5), 0.5)),
+                ]
+                @testset "$k_conv" for (k_conv, k) in unstretched
+                    @test pw(k_conv, x0) ≈ pw(k, x0)
+                    differentiable_kernel_tests(k_conv, ȳ, Ȳ, Ȳ_sq, x0, x1, x2)
+                end
+                @testset "$k_conv" for (k_conv, k) in stretched
+                    @test pw(k_conv, x0) ≈ pw(k, x0)
+                    differentiable_kernel_tests(k_conv, ȳ, Ȳ, Ȳ_sq, x0, x1, x2)
+                end
             end
         end
     end

--- a/test/gp/mean.jl
+++ b/test/gp/mean.jl
@@ -12,7 +12,7 @@ using Stheno: CustomMean, ZeroMean, OneMean, ConstMean
     end
     @timedtestset "ZeroMean" begin
         rng, P, Q, D = MersenneTwister(123456), 3, 2, 4
-        X, x = ColsAreObs(randn(rng, D, P)), randn(rng, P)
+        X, x = ColVecs(randn(rng, D, P)), randn(rng, P)
         f = ZeroMean{Float64}()
 
         for x in [x, X]
@@ -22,7 +22,7 @@ using Stheno: CustomMean, ZeroMean, OneMean, ConstMean
     end
     @timedtestset "OneMean" begin
         rng, P, Q, D = MersenneTwister(123456), 3, 2, 4
-        X, x = ColsAreObs(randn(rng, D, P)), randn(rng, P)
+        X, x = ColVecs(randn(rng, D, P)), randn(rng, P)
         f = OneMean()
 
         for x in [x, X]
@@ -32,7 +32,7 @@ using Stheno: CustomMean, ZeroMean, OneMean, ConstMean
     end
     @timedtestset "ConstMean" begin
         rng, D, N = MersenneTwister(123456), 5, 3
-        X, x, c = ColsAreObs(randn(rng, D, N)), randn(rng, N), randn(rng)
+        X, x, c = ColVecs(randn(rng, D, N)), randn(rng, N), randn(rng)
         m = ConstMean(c)
 
         for x in [x, X]

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -36,7 +36,7 @@ include("test_util.jl")
         include(joinpath("gp", "mean.jl"))
         include(joinpath("gp", "kernel.jl"))
         include(joinpath("gp", "gp.jl"))
-    end    
+    end
 
     println("composite:")
     @timedtestset "composite" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -14,40 +14,40 @@ include("test_util.jl")
 
 @testset "Stheno" begin
 
-    println("util:")
-    @timedtestset "util" begin
-        include(joinpath("util", "zygote_rules.jl"))
-        include(joinpath("util", "covariance_matrices.jl"))
-        @testset "block_arrays" begin
-            include(joinpath("util", "block_arrays", "test_util.jl"))
-            include(joinpath("util", "block_arrays", "dense.jl"))
-            include(joinpath("util", "block_arrays", "diagonal.jl"))
-        end
-        include(joinpath("util", "abstract_data_set.jl"))
-    end
+    # println("util:")
+    # @timedtestset "util" begin
+    #     include(joinpath("util", "zygote_rules.jl"))
+    #     include(joinpath("util", "covariance_matrices.jl"))
+    #     @testset "block_arrays" begin
+    #         include(joinpath("util", "block_arrays", "test_util.jl"))
+    #         include(joinpath("util", "block_arrays", "dense.jl"))
+    #         include(joinpath("util", "block_arrays", "diagonal.jl"))
+    #     end
+    #     include(joinpath("util", "abstract_data_set.jl"))
+    # end
 
-    println("abstract_gp:")
-    @timedtestset "abstract_gp" begin
-        include("abstract_gp.jl")
-    end
+    # println("abstract_gp:")
+    # @timedtestset "abstract_gp" begin
+    #     include("abstract_gp.jl")
+    # end
 
-    println("gp:")
-    @timedtestset "gp" begin
-        include(joinpath("gp", "mean.jl"))
-        include(joinpath("gp", "kernel.jl"))
-        include(joinpath("gp", "gp.jl"))
-    end
+    # println("gp:")
+    # @timedtestset "gp" begin
+    #     include(joinpath("gp", "mean.jl"))
+    #     include(joinpath("gp", "kernel.jl"))
+    #     include(joinpath("gp", "gp.jl"))
+    # end
 
     println("composite:")
     @timedtestset "composite" begin
         include(joinpath("composite", "test_util.jl"))
-        include(joinpath("composite", "indexing.jl"))
-        include(joinpath("composite", "cross.jl"))
-        include(joinpath("composite", "conditioning.jl"))
-        include(joinpath("composite", "product.jl"))
-        include(joinpath("composite", "addition.jl"))
+        # include(joinpath("composite", "indexing.jl"))
+        # include(joinpath("composite", "cross.jl"))
+        # include(joinpath("composite", "conditioning.jl"))
+        # include(joinpath("composite", "product.jl"))
+        # include(joinpath("composite", "addition.jl"))
         include(joinpath("composite", "compose.jl"))
-        include(joinpath("composite", "approximate_conditioning.jl"))
+        # include(joinpath("composite", "approximate_conditioning.jl"))
     end
 end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -14,42 +14,41 @@ include("test_util.jl")
 
 @testset "Stheno" begin
 
-    # println("util:")
-    # @timedtestset "util" begin
-    #     include(joinpath("util", "zygote_rules.jl"))
-    #     include(joinpath("util", "covariance_matrices.jl"))
-    #     @testset "block_arrays" begin
-    #         include(joinpath("util", "block_arrays", "test_util.jl"))
-    #         include(joinpath("util", "block_arrays", "dense.jl"))
-    #         include(joinpath("util", "block_arrays", "diagonal.jl"))
-    #     end
-    #     include(joinpath("util", "abstract_data_set.jl"))
-    # end
+    println("util:")
+    @timedtestset "util" begin
+        include(joinpath("util", "zygote_rules.jl"))
+        include(joinpath("util", "covariance_matrices.jl"))
+        @testset "block_arrays" begin
+            include(joinpath("util", "block_arrays", "test_util.jl"))
+            include(joinpath("util", "block_arrays", "dense.jl"))
+            include(joinpath("util", "block_arrays", "diagonal.jl"))
+        end
+        include(joinpath("util", "abstract_data_set.jl"))
+    end
 
-    # println("abstract_gp:")
-    # @timedtestset "abstract_gp" begin
-    #     include("abstract_gp.jl")
-    # end
+    println("abstract_gp:")
+    @timedtestset "abstract_gp" begin
+        include("abstract_gp.jl")
+    end
 
-    # println("gp:")
-    # @timedtestset "gp" begin
-    #     include(joinpath("gp", "mean.jl"))
-    #     include(joinpath("gp", "kernel.jl"))
-    #     include(joinpath("gp", "gp.jl"))
-    # end
+    println("gp:")
+    @timedtestset "gp" begin
+        include(joinpath("gp", "mean.jl"))
+        include(joinpath("gp", "kernel.jl"))
+        include(joinpath("gp", "gp.jl"))
+    end
 
     println("composite:")
     @timedtestset "composite" begin
         include(joinpath("composite", "test_util.jl"))
-        # include(joinpath("composite", "indexing.jl"))
-        # include(joinpath("composite", "cross.jl"))
-        # include(joinpath("composite", "conditioning.jl"))
-        # include(joinpath("composite", "product.jl"))
-        # include(joinpath("composite", "addition.jl"))
+        include(joinpath("composite", "indexing.jl"))
+        include(joinpath("composite", "cross.jl"))
+        include(joinpath("composite", "conditioning.jl"))
+        include(joinpath("composite", "product.jl"))
+        include(joinpath("composite", "addition.jl"))
         include(joinpath("composite", "compose.jl"))
-        # include(joinpath("composite", "approximate_conditioning.jl"))
+        include(joinpath("composite", "approximate_conditioning.jl"))
     end
 end
 
 display(to)
-

--- a/test/test_util.jl
+++ b/test/test_util.jl
@@ -27,9 +27,9 @@ function print_adjoints(adjoint_ad, adjoint_fd, rtol, atol)
 end
 
 # AbstractArrays.
-function to_vec(x::ColsAreObs{<:Real})
+function to_vec(x::ColVecs{<:Real})
     x_vec, back = to_vec(x.X)
-    return x_vec, x_vec -> ColsAreObs(back(x_vec))
+    return x_vec, x_vec -> ColVecs(back(x_vec))
 end
 to_vec(x::BlockArray) = vec(Array(x)), x_->BlockArray(reshape(x_, size(x)), blocksizes(x))
 function to_vec(x::BlockData)
@@ -185,7 +185,7 @@ end
 function differentiable_mean_function_tests(
     m::MeanFunction,
     ȳ::AbstractVector{<:Real},
-    x::ColsAreObs{<:Real};
+    x::ColVecs{<:Real};
     rtol=_rtol,
     atol=_atol,
 )
@@ -193,7 +193,7 @@ function differentiable_mean_function_tests(
     mean_function_tests(m, x)
 
     @assert length(ȳ) == length(x)
-    adjoint_test(X->ew(m, ColsAreObs(X)), ȳ, x.X; rtol=rtol, atol=atol)  
+    adjoint_test(X->ew(m, ColVecs(X)), ȳ, x.X; rtol=rtol, atol=atol)  
 end
 function differentiable_mean_function_tests(
     rng::AbstractRNG,

--- a/test/util/abstract_data_set.jl
+++ b/test/util/abstract_data_set.jl
@@ -1,30 +1,30 @@
 using Random, LinearAlgebra, Zygote
-using Stheno: ColsAreObs, BlockData
+using Stheno: ColVecs, BlockData
 
 @timedtestset "abstract_data_set" begin
     rng, N, D = MersenneTwister(123456), 10, 2
     x, X = randn(rng, N), randn(rng, D, N)
 
     # Test Matrix data sets.
-    @timedtestset "ColsAreObs" begin
-        DX = ColsAreObs(X)
+    @timedtestset "ColVecs" begin
+        DX = ColVecs(X)
         @test DX == DX
         @test size(DX) == (N,)
         @test length(DX) == N
         @test getindex(DX, 5) isa Vector
         @test getindex(DX, 5) == X[:, 5]
-        @test getindex(DX, 1:2:6) isa ColsAreObs
-        @test getindex(DX, 1:2:6) == ColsAreObs(X[:, 1:2:6])
+        @test getindex(DX, 1:2:6) isa ColVecs
+        @test getindex(DX, 1:2:6) == ColVecs(X[:, 1:2:6])
         @test view(DX, 4) isa AbstractVector
         @test view(DX, 4) == view(X, :, 4)
-        @test view(DX, 1:2:4) isa ColsAreObs
-        @test view(DX, 1:2:4) == ColsAreObs(view(X, :, 1:2:4))
+        @test view(DX, 1:2:4) isa ColVecs
+        @test view(DX, 1:2:4) == ColVecs(view(X, :, 1:2:4))
         @test eltype(DX) == Vector{Float64}
         @test eachindex(DX) == 1:N
 
         let
-            @test Zygote.forward(ColsAreObs, X)[1] == DX
-            DX, back = Zygote.forward(ColsAreObs, X)
+            @test Zygote.forward(ColVecs, X)[1] == DX
+            DX, back = Zygote.forward(ColVecs, X)
             @test back((X=ones(size(X)),))[1] == ones(size(X))
 
             @test Zygote.forward(DX->DX.X, DX)[1] == X
@@ -35,7 +35,7 @@ using Stheno: ColsAreObs, BlockData
 
     # Test BlockDataSet.
     @timedtestset "BlockData" begin
-        DX = ColsAreObs(X)
+        DX = ColVecs(X)
         DxX = BlockData([x, DX])
         @test size(DxX) == (2N,)
         @test length(DxX) == 2N

--- a/test/util/zygote_rules.jl
+++ b/test/util/zygote_rules.jl
@@ -31,7 +31,10 @@ using Base.Broadcast: broadcast_shape
     @timedtestset "pairwise(::Euclidean, X, Y; dims=2)" begin
         rng, D, P, Q = MersenneTwister(123456), 2, 3, 5
         X, Y, D̄ = randn(rng, D, P), randn(rng, D, Q), randn(rng, P, Q)
-        adjoint_test((X, Y)->pairwise(Euclidean(), X, Y; dims=2), D̄, X, Y)
+        adjoint_test(
+            (X, Y)->pairwise(Euclidean(), X, Y; dims=2), D̄, X, Y;
+            rtol=1e-6, atol=1e-6,
+        )
     end
     @timedtestset "pairwise(::Euclidean, X; dims=2)" begin
         rng, D, P = MersenneTwister(123456), 2, 3


### PR DESCRIPTION
Various changes moving this package towards 1.0, including

- Renaming `ColsAreObs` to `ColVecs`
- Documentation for the various input types (@MichielStock if you have a few minutes to read over the new page of the documentation, it would be much appreciated)
- Multi-sample `logpdf` + tests, so a matrix of outputs can now be provided, where each _column_ will be treated as an observation.
- `ApproxObs` -> `PseudoObs`, and various interface changes have been added, + tests.
- The `shift` composition operator to translate GPs around their input spaces.
- `GP(kernel, mean_function, gpc)` now provides a valid way to instantiate a GP.
- Tests for most custom compositions (`stretch`, `shift`, `select`) added.