### PR TITLE
Fix some performance issues

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,6 @@ git:
 matrix:
  allow_failures:
  - julia: nightly
- - julia: 1.3
 
 ## uncomment and modify the following lines to manually install system packages
 #addons:

--- a/src/gp/kernel.jl
+++ b/src/gp/kernel.jl
@@ -135,7 +135,7 @@ The Matern kernel with ν = 3 / 2
 """
 struct Matern32 <: Kernel end
 
-function _matern32(d)
+function _matern32(d::Real)
     d = sqrt(3) * d
     return (1 + d) * exp(-d)
 end
@@ -157,18 +157,26 @@ The Matern kernel with ν = 5 / 2
 """
 struct Matern52 <: Kernel end
 
-function _matern52(d)
-    d = sqrt(5) * d
-    return (1 + d + d^2 / 3) * exp(-d)
+function _matern52(d::Real)
+    λ = sqrt(5) * d
+    return (1 + λ + λ^2 / 3) * exp(-λ)
+end
+
+_matern52(d::AbstractArray{<:Real}) = _matern52.(d)
+
+@adjoint function _matern52(d::AbstractArray{<:Real})
+    λ = sqrt(5) .* d
+    b = exp.(-λ)
+    return (1 .+ λ .+ λ.^2 ./ 3) .* b, Δ->(.-Δ .* sqrt(5) .* b .* λ .* (1 .+ λ) ./ 3,)
 end
 
 # Binary methods
-ew(k::Matern52, x::AV, x′::AV) = _matern52.(ew(Euclidean(), x, x′))
-pw(k::Matern52, x::AV, x′::AV) = _matern52.(pw(Euclidean(), x, x′))
+ew(k::Matern52, x::AV, x′::AV) = _matern52(ew(Euclidean(), x, x′))
+pw(k::Matern52, x::AV, x′::AV) = _matern52(pw(Euclidean(), x, x′))
 
 # Unary methods
-ew(k::Matern52, x::AV) = _matern52.(ew(Euclidean(), x))
-pw(k::Matern52, x::AV) = _matern52.(pw(Euclidean(), x))
+ew(k::Matern52, x::AV) = _matern52(ew(Euclidean(), x))
+pw(k::Matern52, x::AV) = _matern52(pw(Euclidean(), x))
 
 
 
@@ -348,6 +356,8 @@ pw(k::Precomputed, x::AV{<:Integer}) = k.K[x,x]
 
 precomputed(K::AbstractMatrix) = Precomputed(K)
 export precomputed
+
+
 
 #
 # Composite Kernels

--- a/src/util/distances.jl
+++ b/src/util/distances.jl
@@ -2,10 +2,10 @@
 for (d, D) in [(:sqeuclidean, :SqEuclidean), (:euclidean, :Euclidean)]
     @eval begin
         function ew(d::$D, x::AV{<:Real}, x′::AV{<:Real})
-            return colwise(d, reshape(x, 1, :), reshape(x′, 1, :); dims=2)
+            return colwise($D(), reshape(x, 1, :), reshape(x′, 1, :))
         end
         function pw(d::$D, x::AV{<:Real}, x′::AV{<:Real})
-            return pw(d, reshape(x, 1, :), reshape(x′, 1, :); dims=2)
+            return pw($D(), reshape(x, 1, :), reshape(x′, 1, :); dims=2)
         end
 
         ew(::$D, x::AV{T}) where {T<:Real} = zeros(T, length(x))

--- a/src/util/distances.jl
+++ b/src/util/distances.jl
@@ -1,8 +1,12 @@
 # Implement some extensions to Euclidean and Squared-Euclidean distances.
 for (d, D) in [(:sqeuclidean, :SqEuclidean), (:euclidean, :Euclidean)]
     @eval begin
-        ew(::$D, x::AV{<:Real}, x′::AV{<:Real}) = $d.(x, x′)
-        pw(::$D, x::AV{<:Real}, x′::AV{<:Real}) = $d.(x, x′')
+        function ew(d::$D, x::AV{<:Real}, x′::AV{<:Real})
+            return colwise(d, reshape(x, 1, :), reshape(x′, 1, :); dims=2)
+        end
+        function pw(d::$D, x::AV{<:Real}, x′::AV{<:Real})
+            return pw(d, reshape(x, 1, :), reshape(x′, 1, :); dims=2)
+        end
 
         ew(::$D, x::AV{T}) where {T<:Real} = zeros(T, length(x))
         pw(::$D, x::AV{<:Real}) = pairwise($D(), x, x)

--- a/src/util/zygote_rules.jl
+++ b/src/util/zygote_rules.jl
@@ -69,3 +69,19 @@ Zygote._symmetric_back(Δ::Diagonal) = Δ
 
 # Diagonal matrices are always symmetric...
 cholesky(A::HermOrSym{T, <:Diagonal{T}} where T) = cholesky(Diagonal(diag(A)))
+
+
+
+#
+# Some very specific broadcasting hacks while Zygote has crappy broadcasting.
+#
+
+import Base.Broadcast: broadcasted
+
+@adjoint broadcasted(::typeof(-), x::AbstractArray) = .-x, Δ->(nothing, .-Δ,)
+
+@adjoint function broadcasted(::typeof(exp), x::AbstractArray)
+    y = exp.(x)
+    return y, Δ->(nothing, Δ .* y)
+end
+

--- a/test/gp/kernel.jl
+++ b/test/gp/kernel.jl
@@ -130,11 +130,12 @@ using LinearAlgebra
         end
 
         @timedtestset "precomputed" begin
+            rng = MersenneTwister(123456)
             x = ColVecs(randn(rng, N, N))
             K = pw(linear(), x)
             k = precomputed(K)
             @test pw(k, 1:N) == pw(linear(), x)
-            @test ew(k, 1:N) == ew(linear(), x)
+            @test ew(k, 1:N) ≈ ew(linear(), x)
             kernel_tests(k, 1:N-1, 2:N, 1:N)
         end
 
@@ -166,11 +167,11 @@ using LinearAlgebra
             end
             @timedtestset "Vector a" begin
                 k = stretch(EQ(), randn(rng, D))
-                differentiable_kernel_tests(k, ȳ, Ȳ, Ȳ_sq, X0, X1, X2)
+                differentiable_kernel_tests(k, ȳ, Ȳ, Ȳ_sq, X0, X1, X2; atol=1e-7, rtol=1e-7)
             end
             @timedtestset "Matrix a" begin
                 k = stretch(EQ(), randn(rng, D, D))
-                differentiable_kernel_tests(k, ȳ, Ȳ, Ȳ_sq, X0, X1, X2)
+                differentiable_kernel_tests(k, ȳ, Ȳ, Ȳ_sq, X0, X1, X2; atol=1e-7, rtol=1e-7)
             end
             @timedtestset "Convenience Constructors" begin
                 unstretched = [

--- a/test/gp/kernel.jl
+++ b/test/gp/kernel.jl
@@ -60,15 +60,6 @@ using LinearAlgebra
             differentiable_kernel_tests(Matern52(), ȳ, Ȳ, Ȳ_sq, X0, X1, X2)
         end
 
-        @timedtestset "precomputed" begin
-            x = ColVecs(randn(rng, N, N))
-            K = pw(linear(), x)
-            k = precomputed(K)
-            @test pw(k, 1:N) == pw(linear(), x)
-            @test ew(k, 1:N) == ew(linear(), x)
-            kernel_tests(k, 1:N-1, 2:N, 1:N)
-        end
-
         @timedtestset "RQ" begin
             @timedtestset "α=1.0" begin
                 differentiable_kernel_tests(RQ(1.0), ȳ, Ȳ, Ȳ_sq, x0, x1, x2)
@@ -136,6 +127,15 @@ using LinearAlgebra
             @test pw(Noise(), x0, x0) == zeros(length(x0), length(x0))
             @test ew(Noise(), x0) == ones(length(x0))
             @test pw(Noise(), x0) == Diagonal(ones(length(x0)))
+        end
+
+        @timedtestset "precomputed" begin
+            x = ColVecs(randn(rng, N, N))
+            K = pw(linear(), x)
+            k = precomputed(K)
+            @test pw(k, 1:N) == pw(linear(), x)
+            @test ew(k, 1:N) == ew(linear(), x)
+            kernel_tests(k, 1:N-1, 2:N, 1:N)
         end
 
         @timedtestset "Sum" begin

--- a/test/util/zygote_rules.jl
+++ b/test/util/zygote_rules.jl
@@ -46,4 +46,14 @@ using Base.Broadcast: broadcast_shape
         adjoint_test(Diagonal, rand(rng, N, N), randn(rng, N))
         adjoint_test(x->Diagonal(x).diag, randn(rng, N), randn(rng, N))
     end
+    @timedtestset "broadcast" begin
+        @timedtestset "exp" begin
+            rng, N = MersenneTwister(123456), 11
+            adjoint_test(x->exp.(x), randn(rng, N), randn(rng, N))
+        end
+        @timedtestset "-" begin
+            rng, N = MersenneTwister(123456), 11
+            adjoint_test(x->.-x, randn(rng, N), randn(rng, N))
+        end
+    end
 end


### PR DESCRIPTION
Fixes some AD-related performance issues, specifically

- `ew` and `pw` for `SqEuclidean` and `Euclidean` with `Vector{<:Real}`-valued input
- broadcasting `-` and `exp`. There's some work that needs to happen in Zygote to make this stuff fast generally, so hopefully we'll be able to remove these soon.