### PR TITLE
Resolve numerical instabilities for close distance calculations

### DIFF
--- a/src/util/distances.jl
+++ b/src/util/distances.jl
@@ -2,25 +2,25 @@
 for (d, D) in [(:sqeuclidean, :SqEuclidean), (:euclidean, :Euclidean)]
     @eval begin
         function ew(d::$D, x::AV{<:Real}, x′::AV{<:Real})
-            return colwise($D(), reshape(x, 1, :), reshape(x′, 1, :))
+            return colwise($D(dtol), reshape(x, 1, :), reshape(x′, 1, :))
         end
         function pw(d::$D, x::AV{<:Real}, x′::AV{<:Real})
-            return pw($D(), reshape(x, 1, :), reshape(x′, 1, :); dims=2)
+            return pw($D(dtol), reshape(x, 1, :), reshape(x′, 1, :); dims=2)
         end
 
         ew(::$D, x::AV{T}) where {T<:Real} = zeros(T, length(x))
-        pw(::$D, x::AV{<:Real}) = pairwise($D(), x, x)
+        pw(::$D, x::AV{<:Real}) = pairwise($D(dtol), x, x)
 
-        ew(::$D, x::ColVecs{<:Real}, x′::ColVecs{<:Real}) = colwise($D(), x.X, x′.X)
-        pw(::$D, x::ColVecs{<:Real}, x′::ColVecs{<:Real}) = pw($D(), x.X, x′.X; dims=2)
+        ew(::$D, x::ColVecs{<:Real}, x′::ColVecs{<:Real}) = colwise($D(dtol), x.X, x′.X)
+        pw(::$D, x::ColVecs{<:Real}, x′::ColVecs{<:Real}) = pw($D(dtol), x.X, x′.X; dims=2)
 
         ew(::$D, x::ColVecs{T}) where {T<:Real} = zeros(T, length(x))
-        pw(::$D, x::ColVecs{<:Real}) = pairwise($D(), x.X; dims=2)
+        pw(::$D, x::ColVecs{<:Real}) = pairwise($D(dtol), x.X; dims=2)
     end
 end
 
 @adjoint function pairwise(::Euclidean, X::AV{<:Real})
-    D, back = Zygote.pullback(X->pairwise(SqEuclidean(), X), X)
+    D, back = Zygote.pullback(X->pairwise(SqEuclidean(dtol), X), X)
     D .= sqrt.(D)
     return D, function(Δ)
         Δ = Δ ./ (2 .* D)

--- a/test/util/zygote_rules.jl
+++ b/test/util/zygote_rules.jl
@@ -56,4 +56,13 @@ using Base.Broadcast: broadcast_shape
             adjoint_test(x->.-x, randn(rng, N), randn(rng, N))
         end
     end
+    @timedtestset "Pairwise when X ≈ Y" begin
+        rng, D, P = MersenneTwister(123456), 2, 100, 5
+        X, D̄ = randn(rng, D, P), randn(rng, P, P)
+        Y = X .+ 1e-8
+        adjoint_test(
+            (X, Y)->pairwise(Euclidean(), X, Y; dims=2), D̄, X, Y;
+            rtol=1e-6, atol=1e-6,
+        )
+    end
 end

--- a/test/util/zygote_rules.jl
+++ b/test/util/zygote_rules.jl
@@ -57,12 +57,12 @@ using Base.Broadcast: broadcast_shape
         end
     end
     @timedtestset "Pairwise when X ≈ Y" begin
-        rng, D, P = MersenneTwister(123456), 2, 100, 5
+        rng, D, P = MersenneTwister(13), 2, 3, 5
         X, D̄ = randn(rng, D, P), randn(rng, P, P)
         Y = X .+ 1e-8
         adjoint_test(
-            (X, Y)->pairwise(Euclidean(), X, Y; dims=2), D̄, X, Y;
-            rtol=1e-6, atol=1e-6,
-        )
+            (X, Y)->pairwise(Euclidean(Stheno.dtol), X, Y; dims=2), D̄, X, Y;
+            rtol=1e-3, atol=1e-3, fdm=FiniteDifferences.Forward(2, 1)
+        ) # relaxed test because of machine precision concerns with finite differences
     end
 end


### PR DESCRIPTION
I'm pleased to report that this fixes #71 

Testing this is kind of tricky - I found a Random seed where #71 triggered, then I compare this to the finite difference solution under relaxed tolerances, as this is exactly the kind of situation finite difference differentiation performs poorly in.

I've added a `const dtol = 1e-12` which sets the parameter to triggering precise recalculation across all `Euclidean` and `SqEuclidean` calls.

My benchmarking showed no difference in timings between this PR and master.