### PR TITLE
Fix Diagonal perf

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -6,6 +6,10 @@ between versions, and discuss new features.
 If you find a breaking change this is not reported here, please either raise an issue or
 make a PR to ammend this document.
 
+## 0.6.1
+
+- Fixed performance bug in reverse-mode gradient computation for the `ELBO`, whereby an `O(N^3)` computation happened in cases where it shouldn't.
+
 ## 0.6.0
 
 ### Breaking changes

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Stheno"
 uuid = "8188c328-b5d6-583d-959b-9690869a5511"
-version = "0.6.0"
+version = "0.6.1"
 
 [deps]
 BlockArrays = "8e7c35d0-a365-5155-bbbb-fb81a777f24e"

--- a/src/util/zygote_rules.jl
+++ b/src/util/zygote_rules.jl
@@ -85,3 +85,13 @@ import Base.Broadcast: broadcasted
     y = exp.(x)
     return y, Δ->(nothing, Δ .* y)
 end
+
+@adjoint function \(D::Diagonal{<:Real}, B::AbstractVecOrMat{<:Real})
+    Y = D \ B
+    function ldiv_Diagonal_pullback(Ȳ::AbstractVecOrMat{<:Real})
+        B̄ = D' \ Ȳ
+        D̄ = Diagonal(-vec(sum(B̄ .* Y; dims=2)))
+        return (D̄, B̄)
+    end
+    return Y, ldiv_Diagonal_pullback
+end

--- a/test/util/zygote_rules.jl
+++ b/test/util/zygote_rules.jl
@@ -65,4 +65,11 @@ using Base.Broadcast: broadcast_shape
             rtol=1e-3, atol=1e-3, fdm=FiniteDifferences.Forward(2, 1)
         ) # relaxed test because of machine precision concerns with finite differences
     end
+    @timedtestset "ldiv(::Diagonal, ::Matrix)" begin
+        rng, P, Q = MersenneTwister(123456), 13, 15
+        Ȳ = randn(rng, P, Q)
+        d = randn(rng, P)
+        X = randn(rng, P, Q)
+        adjoint_test((d, X)->Diagonal(d) \ X, Ȳ, d, X)
+    end
 end


### PR DESCRIPTION
Patch to make AD play nicely with backsolving against a `Diagonal` matrix.