### PR TITLE
Begin @adjoint -> ChainRules

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ os:
   - windows
 julia:
   - 1.3
-  - 1.4
+  - 1
   - nightly
 notifications:
   email: false

--- a/Project.toml
+++ b/Project.toml
@@ -4,6 +4,7 @@ version = "0.6.6"
 
 [deps]
 BlockArrays = "8e7c35d0-a365-5155-bbbb-fb81a777f24e"
+ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"
 Distances = "b4f34e82-e78d-54a5-968a-f98e89d6e8f7"
 Distributions = "31c24e10-a181-5473-b8eb-7969acd0382f"
 FillArrays = "1a297f60-69ca-5386-bcde-b61e274b549b"
@@ -18,6 +19,7 @@ ZygoteRules = "700de1a5-db45-46bc-99cf-38207098b444"
 
 [compat]
 BlockArrays = "0.12"
+ChainRulesCore = "0.9"
 Distances = "0.8, 0.9"
 Distributions = "0.19, 0.20, 0.21, 0.22, 0.23"
 FillArrays = "0.7, 0.8"
@@ -26,7 +28,7 @@ Flux = "0.9, 0.10, 0.11"
 MacroTools = "0.4, 0.5"
 RecipesBase = "0.7, 0.8, 1"
 Requires = "1"
-Zygote = "0.4.6, 0.5"
+Zygote = "0.5"
 ZygoteRules = "0.2"
 julia = "1.1.1"
 

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Stheno"
 uuid = "8188c328-b5d6-583d-959b-9690869a5511"
-version = "0.6.6"
+version = "0.6.7"
 
 [deps]
 BlockArrays = "8e7c35d0-a365-5155-bbbb-fb81a777f24e"

--- a/src/Stheno.jl
+++ b/src/Stheno.jl
@@ -11,7 +11,7 @@ module Stheno
         Random,
         Requires,
         Zygote,
-        ZygoteRules,
+        ZygoteRules
 
     import Base: length, map
     import Base.Broadcast: broadcasted, materialize, broadcast_shape

--- a/src/Stheno.jl
+++ b/src/Stheno.jl
@@ -15,6 +15,7 @@ module Stheno
 
     import Base: length, map
     import Base.Broadcast: broadcasted, materialize, broadcast_shape
+    import ChainRulesCore: rrule
     import Statistics: mean, cov
     using ZygoteRules: @adjoint
     using Zygote: @nograd

--- a/src/Stheno.jl
+++ b/src/Stheno.jl
@@ -1,7 +1,18 @@
 module Stheno
 
-    using Distributions, Distances, BlockArrays, Statistics, Random, FillArrays,
-       LinearAlgebra, Zygote, ZygoteRules, Requires
+    using
+        BlockArrays,
+        ChainRulesCore,
+        Distributions,
+        Distances,
+        FillArrays,
+        LinearAlgebra,
+        Statistics,
+        Random,
+        Requires,
+        Zygote,
+        ZygoteRules,
+
     import Base: length, map
     import Base.Broadcast: broadcasted, materialize, broadcast_shape
     import Statistics: mean, cov

--- a/src/composite/compose.jl
+++ b/src/composite/compose.jl
@@ -69,9 +69,11 @@ function broadcasted(f::Select, x::AbstractVector{<:CartesianIndex})
     end
     return ColVecs(out)
 end
-@adjoint function broadcasted(f::Select, x::AV{<:CartesianIndex})
-    return broadcasted(f, x), Δ->(nothing, nothing)
+
+function rrule(::typeof(broadcasted), f::Select, x::AV{<:CartesianIndex})
+    return broadcasted(f, x), Δ->(NO_FIELDS, DoesNotExist(), Zero())
 end
+
 function broadcasted(f::Select{<:Integer}, x::AV{<:CartesianIndex})
     out = Matrix{Int}(undef, length(x))
     for n in eachindex(x)

--- a/src/util/abstract_data_set.jl
+++ b/src/util/abstract_data_set.jl
@@ -13,9 +13,9 @@ struct ColVecs{T, TX<:AbstractMatrix{T}} <: AbstractVector{Vector{T}}
     ColVecs(X::TX) where {T, TX<:AbstractMatrix{T}} = new{T, TX}(X)
 end
 
-@adjoint function ColVecs(X::AbstractMatrix)
-    back(Δ::NamedTuple) = (Δ.X,)
-    back(Δ::AbstractMatrix) = (Δ,)
+function rrule(::typeof(ColVecs), X::AbstractMatrix)
+    back(Δ::Composite) = (NO_FIELDS, Δ.X,)
+    back(Δ::AbstractMatrix) = (NO_FIELDS, Δ,)
     function back(Δ::AbstractVector{<:AbstractVector{<:Real}})
         throw(error("In slow method"))
     end

--- a/src/util/block_arrays/dense.jl
+++ b/src/util/block_arrays/dense.jl
@@ -30,9 +30,9 @@ result is itself straightforwardly representable as `BlockVecOrMat`.
 """
 are_conformal(A::AVM, B::AVM) = blocksizes(A, 2) == blocksizes(B, 1)
 
-ZygoteRules.@adjoint function BlockArrays.mortar(_blocks::AbstractArray)
-    function mortar_pullback(Δ::NamedTuple{(:blocks, :axes)})
-        return (Δ.blocks, )
+function rrule(::typeof(BlockArrays.mortar), _blocks::AbstractArray)
+    function mortar_pullback(Δ::Composite)
+        return (NO_FIELDS, Δ.blocks, )
     end
     function mortar_pullback(Δ::BlockArray)
         return mortar_pullback((blocks = Δ.blocks, axes=nothing))
@@ -42,7 +42,8 @@ end
 
 ZygoteRules.@adjoint function BlockArrays.Array(X::BlockArray)
     function Array_pullback(Δ::Array)
-        return ((blocks=BlockArray(Δ, axes(X)).blocks, axes=nothing), )
+        ΔX = (blocks=BlockArray(Δ, axes(X)).blocks, axes=nothing)
+        return (ΔX,)
     end
     return Array(X), Array_pullback
 end

--- a/src/util/block_arrays/dense.jl
+++ b/src/util/block_arrays/dense.jl
@@ -30,9 +30,9 @@ result is itself straightforwardly representable as `BlockVecOrMat`.
 """
 are_conformal(A::AVM, B::AVM) = blocksizes(A, 2) == blocksizes(B, 1)
 
-function rrule(::typeof(BlockArrays.mortar), _blocks::AbstractArray)
-    function mortar_pullback(Δ::Composite)
-        return (NO_FIELDS, Δ.blocks, )
+ZygoteRules.@adjoint function BlockArrays.mortar(_blocks::AbstractArray)
+    function mortar_pullback(Δ::NamedTuple{(:blocks, :axes)})
+        return (Δ.blocks, )
     end
     function mortar_pullback(Δ::BlockArray)
         return mortar_pullback((blocks = Δ.blocks, axes=nothing))

--- a/src/util/distances.jl
+++ b/src/util/distances.jl
@@ -19,7 +19,7 @@ for (d, D) in [(:sqeuclidean, :SqEuclidean), (:euclidean, :Euclidean)]
     end
 end
 
-function ChainRulesCore.rrule(::typeof(pairwise), ::Euclidean, x::AbstractVector{<:Real})
+function rrule(::typeof(pairwise), ::Euclidean, x::AbstractVector{<:Real})
     D, back = Zygote.pullback(x->pairwise(SqEuclidean(dtol), x), x)
     D .= sqrt.(D)
     return D, function(Δ)

--- a/src/util/distances.jl
+++ b/src/util/distances.jl
@@ -19,12 +19,12 @@ for (d, D) in [(:sqeuclidean, :SqEuclidean), (:euclidean, :Euclidean)]
     end
 end
 
-@adjoint function pairwise(::Euclidean, X::AV{<:Real})
-    D, back = Zygote.pullback(X->pairwise(SqEuclidean(dtol), X), X)
+function ChainRulesCore.rrule(::typeof(pairwise), ::Euclidean, x::AbstractVector{<:Real})
+    D, back = Zygote.pullback(x->pairwise(SqEuclidean(dtol), x), x)
     D .= sqrt.(D)
     return D, function(Δ)
         Δ = Δ ./ (2 .* D)
         Δ[diagind(Δ)] .= 0
-        return (nothing, first(back(Δ)))
+        return (NO_FIELDS, NO_FIELDS, first(back(Δ)))
     end
 end

--- a/src/util/zygote_rules.jl
+++ b/src/util/zygote_rules.jl
@@ -15,8 +15,7 @@ end
 accum(A::AbstractMatrix, D::Diagonal) = accum(D, A)
 accum(A::Diagonal, B::Diagonal) = Diagonal(accum(diag(A), diag(B)))
 
-function rrule(::typeof(ZygoteRules.literal_getproperty), C::Cholesky, ::Val{:factors})
-    println("doing f")
+@adjoint function ZygoteRules.literal_getproperty(C::Cholesky, ::Val{:factors})
     error("@adjoint not implemented for :factors as is unsafe.")
     return literal_getproperty(C, Val(:factors)), function(Δ)
         error("@adjoint not implemented for :factors. (I couldn't make it work...)")


### PR DESCRIPTION
It's possible to transfer many of the rules over to `ChainRules`. However, there remain quite a few rules that can't be transferred over due to `Zygote`s `@adjoint` macro taking precedence over `rrule`, and there still being a large number of rules in `Zygote` that are implemented this way.
