### PR TITLE
Fix Eucidean

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Stheno"
 uuid = "8188c328-b5d6-583d-959b-9690869a5511"
-version = "0.6.10"
+version = "0.6.11"
 
 [deps]
 BlockArrays = "8e7c35d0-a365-5155-bbbb-fb81a777f24e"

--- a/src/util/distances.jl
+++ b/src/util/distances.jl
@@ -23,7 +23,8 @@ function rrule(::typeof(pairwise), ::Euclidean, x::AbstractVector{<:Real})
     D, back = Zygote.pullback(x->pairwise(SqEuclidean(dtol), x), x)
     D .= sqrt.(D)
     return D, function(Δ)
-        Δ = Δ ./ (2 .* D)
+        Δ = Δ ./ (2 .* max.(D, eps(eltype(D))))
+        # Δ = Δ ./ (2 .* D)
         Δ[diagind(Δ)] .= 0
         return (NO_FIELDS, NO_FIELDS, first(back(Δ)))
     end

--- a/test/util/distances.jl
+++ b/test/util/distances.jl
@@ -76,6 +76,6 @@ end
         x_ = randn(N)
         x = vcat(x_, x_)
         ΔD = randn(2N, 2N)
-        adjoint_test(x -> pairwise(Euclidean(), x), ΔD, x; atol=1e-8, rtol=1e-8)
+        adjoint_test(x -> pairwise(Euclidean(), x), ΔD, x; atol=1e-6, rtol=1e-6, print_results=true)
     end
 end

--- a/test/util/distances.jl
+++ b/test/util/distances.jl
@@ -72,7 +72,7 @@ end
     end
 
     @testset "Euclidean with repeated inputs" begin
-        N = 25
+        N = 5
         x_ = randn(N)
         x = vcat(x_, x_)
         ΔD = randn(2N, 2N)

--- a/test/util/distances.jl
+++ b/test/util/distances.jl
@@ -72,22 +72,10 @@ end
     end
 
     @testset "Euclidean with repeated inputs" begin
-        x_ = randn(5)
+        N = 25
+        x_ = randn(N)
         x = vcat(x_, x_)
-        ΔD = randn(10, 10)
-
-        # Compute forwards-pass and j′vp.
-        f = x -> pairwise(Euclidean(), x)
-        D, back = Zygote.pullback(f, x)
-        @timeit to "adj_ad" adj_ad = back(ΔD)
-        @timeit to "adj_fd" adj_fd = j′vp(central_fdm(5, 1), f, ΔD, x)
-
-        # Check that forwards-pass agrees with plain forwards-pass.
-        @test D ≈ f(x)
-
-        # Check that ad and fd adjoints (approximately) agree.
-        # print_results && print_adjoints(adj_ad, adj_fd, rtol, atol)
-        @test fd_isapprox(adj_ad, adj_fd, 1e-6, 1e-6)
-        # adjoint_test(, ΔD, x; print_results=true)
+        ΔD = randn(2N, 2N)
+        adjoint_test(x -> pairwise(Euclidean(), x), ΔD, x; atol=1e-9, rtol=1e-9)
     end
 end

--- a/test/util/distances.jl
+++ b/test/util/distances.jl
@@ -76,6 +76,6 @@ end
         x_ = randn(N)
         x = vcat(x_, x_)
         ΔD = randn(2N, 2N)
-        adjoint_test(x -> pairwise(Euclidean(), x), ΔD, x; atol=1e-9, rtol=1e-9)
+        adjoint_test(x -> pairwise(Euclidean(), x), ΔD, x; atol=1e-8, rtol=1e-8)
     end
 end


### PR DESCRIPTION
This is an attempt to fix the problems addressed in #121 .

The fix implemented is similar to the fix recently implemented in Zygote, but also results in some weird quantisation issues.

@molet @oxinabox @evanmunro any thoughts on what might be going wrong with the numerics here? I suspect that Zygote is also still suffering from this issue, but here we're computing the euclidean distance between scalars rather than vectors. Any thoughts on what might be going wrong? (See the test on line 90 -- it fails)

It's possible that the quantisation effects that we're seeing are actually reasonable, and its finite differencing that is breaking down around the discontinuity. Either way, it would be great to get to the bottom of this once and for all.

Once we've resolved this here, it will hopefully be straightforward to port the solution over to Zygote.